### PR TITLE
Suggest usage of sudo when root access is needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Issues to review:
 
 ### ZoL (zfs-generic-nfs, zfs-generic-iscsi)
 
-Ensure ssh and zfs is installed on the server and that you have installed
+Ensure ssh and zfs is installed on the nfs/iscsi server and that you have installed
 `targetcli`.
 
-- `yum install targetcli -y`
-- `apt-get -y install targetcli-fb`
+- `sudo yum install targetcli -y`
+- `sudo apt-get -y install targetcli-fb`
 
 ## Helm Installation
 


### PR DESCRIPTION
Also be explicit about requirement for the NFS/iscsi server.

A user has to configured both the NFS/iSCSI server and the kubernetes
nodes it is clearer if the configuration clarifies which "set of
servers" required each type of configuration.  This tiny change
makes that more explicit and the use of sudo is because a lot of
kubernetes commands do not require root, so if root is required it is
good to be explicit.