### PR TITLE
Fix run on armv7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,13 @@ RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* 
 ENV LANG=en_US.utf8
 ENV NODE_ENV=production
 
+# Workaround for https://github.com/nodejs/node/issues/37219
+RUN test $(uname -m) != armv7l || ( \
+                apt-get update \
+                && apt-get install -y libatomic1 \
+                && rm -rf /var/lib/apt/lists/* \
+        )
+
 # install node
 #ENV PATH=/usr/local/lib/nodejs/bin:$PATH
 #COPY --from=build /usr/local/lib/nodejs /usr/local/lib/nodejs


### PR DESCRIPTION
Hey! Recent images of `democratic-csi` crash when launched on armv7l with error: 
```
node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

This is a known nodejs 12 issue for armv7l : https://github.com/nodejs/node/issues/37219

I suggest a temporary solution. The fix was tested on rpi4 with host OS ubuntu 20.04 (32bit). 