### PR TITLE
Set zfs dataset comment using template

### DIFF
--- a/examples/freenas-api-iscsi.yaml
+++ b/examples/freenas-api-iscsi.yaml
@@ -33,6 +33,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # can be used to set the comments field in the UI
+  #datasetCommentTemplate: "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   
   # total volume name (zvol/<datasetParentName>/<pvc name>) length cannot exceed 63 chars
   # https://www.ixsystems.com/documentation/freenas/11.2-U5/storage.html#zfs-zvol-config-opts-tab


### PR DESCRIPTION
Adds support for setting the "comments" field for the `freenas-api-iscsi` driver Datasets.

## Screenshot
The comments field is visible in the TrueNas Scale UI (far right column). I use `reclaimPolicy: Retain`, so this is a convenience feature for me to make cleaning up old volumes easier.
 
![screenshot-20220425-190904](https://user-images.githubusercontent.com/293465/165157443-4c7bc229-3856-4846-8589-083c4a22951e.png)


## Tested items

```
---
# Test source pvc.
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: source-pvc
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 256Mi
  storageClassName: truenas-iscsi
status:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 256Mi
---
# Snapshot of the source.
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: source-snapshot
  namespace: default
spec:
  volumeSnapshotClassName: truenas-iscsi
  source:
    persistentVolumeClaimName: source-pvc
---
# Direct clone of source pvc.
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: clone-directly-from-pvc
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  storageClassName: truenas-iscsi
  resources:
    requests:
      storage: 256Mi
  dataSource:
    kind: PersistentVolumeClaim
    name: source-pvc
---
# Restore of snapshot.
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: created-from-snapshot
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  storageClassName: truenas-iscsi
  resources:
    requests:
      storage: 256Mi
  dataSourceRef:
    apiGroup: snapshot.storage.k8s.io
    kind: VolumeSnapshot
    name: source-snapshot
```