### PR TITLE
Apply sudo only to targetcli bin, not entire command

### DIFF
--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -476,19 +476,19 @@ delete ${iscsiName}
 
     let command = "sh";
     let args = ["-c"];
-    let taregetCliCommand = [];
-    taregetCliCommand.push(`echo "${data}"`.trim());
-    taregetCliCommand.push("|");
-    taregetCliCommand.push("targetcli");
 
+    let targetCliArgs = ["targetcli"];
     if (
       _.get(this.options, "iscsi.shareStrategyTargetCli.sudoEnabled", false)
     ) {
-      command = "sudo";
-      args.unshift("sh");
+      targetCliArgs.unshift("sudo");
     }
 
-    args.push("'" + taregetCliCommand.join(" ") + "'");
+    let targetCliCommand = [];
+    targetCliCommand.push(`echo "${data}"`.trim());
+    targetCliCommand.push("|");
+    targetCliCommand.push(targetCliArgs.join(" "));
+    args.push("'" + targetCliCommand.join(" ") + "'");
 
     let logCommandTmp = command + " " + args.join(" ");
     let logCommand = "";


### PR DESCRIPTION
Hello,

I'm having a little problem using democratic-csi with zfs-generic-iscsi implementation when there is a "security hardened" user in position of ssh connection and executing zfs and targetcli commands. The user has enabled creation and property setting of datasets/volumes via zfs allow and can only run targetcli via sudo (without password). Therefore the command (`sudo sh -c "echo [data] | targetcli"`) which is executed when creating iSCSI share for a volume results in timeout (sudo requiring user to enter password which never happens).

In order to prevent granting that user shell sudo permissions I prepared a correction which limits sudo only to the targetcli. That way the user can only have passwordless sudo for targetcli and not entire shell.