### PR TITLE
Don't globally lock volume in NodeGetVolumeStats RPC

### DIFF
--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -87,10 +87,10 @@ function lockKeysFromRequest(call, serviceMethodName) {
     case "NodeUnstageVolume":
     case "NodePublishVolume":
     case "NodeUnpublishVolume":
-    case "NodeGetVolumeStats":
     case "NodeExpandVolume":
       return ["volume_id_" + call.request.volume_id];
 
+    case "NodeGetVolumeStats":
     default:
       return [];
   }


### PR DESCRIPTION
Complete description of the problem this PR solves is in issue #244 