### PR TITLE
Update Nomad NFS example 

### DIFF
--- a/docs/Nomad/examples/democratic-csi-nfs-controller.hcl
+++ b/docs/Nomad/examples/democratic-csi-nfs-controller.hcl
@@ -6,17 +6,44 @@ job "democratic-csi-nfs-controller" {
       driver = "docker"
 
       config {
-        image = "docker.io/democraticcsi/democratic-csi:latest"
+        image = "docker.io/democraticcsi/democratic-csi:${var.version}"
 
-        args = [
-          "--csi-version=1.5.0",
-          # must match the csi_plugin.id attribute below
-          "--csi-name=org.democratic-csi.nfs",
-          "--driver-config-file=${NOMAD_TASK_DIR}/driver-config-file.yaml",
-          "--log-level=info",
-          "--csi-mode=controller",
-          "--server-socket=/csi/csi.sock",
+        entrypoint = [
+          "${NOMAD_TASK_DIR}/init.sh"
         ]
+
+        network_mode = "host"
+        privileged = true
+      }
+
+      env {
+        NFS_SERVER = "<nfs server>"
+        NFS_SHARE  = "<nfs share>"
+      }
+
+      # The nfs share is mounted in the controller so it can create the volumes
+      # sub directories inside the nfs share
+      template {
+        destination = "${NOMAD_TASK_DIR}/init.sh"
+        perms = "755"
+
+        data = <<-EOT
+          #!/bin/sh
+
+          if [ ! -d /storage ]; then
+            mkdir -p /storage
+          fi
+
+          mount "{{ env "NFS_SERVER" }}:{{ env "NFS_SHARE" }}" /storage
+
+          exec ./bin/democratic-csi \
+            --csi-version=1.5.0 \
+            --csi-name=org.democratic-csi.nfs \
+            --driver-config-file={{ env "NOMAD_TASK_DIR" }}/driver-config-file.yaml \
+            --log-level=info \
+            --csi-mode=controller \
+            --server-socket=/csi/csi.sock
+        EOT
       }
 
       template {


### PR DESCRIPTION
Updates the Nomad NFS example controller job to mount the nfs share so it can create the volumes sub directories in the nfs share