### PR TITLE
Fix examples with wrong schema

### DIFF
--- a/examples/node-manual-iscsi-pv.yaml
+++ b/examples/node-manual-iscsi-pv.yaml
@@ -9,21 +9,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  # can be used to handle CHAP
-  # in the secret create the following keys:
-  #
-  #      # any arbitrary iscsiadm entries can be add by creating keys starting with node-db.<entry.name>
-  #      # if doing CHAP
-  #      node-db.node.session.auth.authmethod: CHAP
-  #      node-db.node.session.auth.username: foo
-  #      node-db.node.session.auth.password: bar
-  #
-  #      # if doing mutual CHAP
-  #      node-db.node.session.auth.username_in: baz
-  #      node-db.node.session.auth.password_in: bar
-  #nodeStageSecretRef:
-  #  name: some name
-  #  namespace: some namespace
   mountOptions: []
   csi:
     driver: org.democratic-csi.node-manual
@@ -31,6 +16,21 @@ spec:
     # can be ext4 or xfs
     fsType: ext4
     volumeHandle: unique-volumeid  # make sure it's a unique id in the cluster
+    # can be used to handle CHAP
+    # in the secret create the following keys:
+    #
+    #      # any arbitrary iscsiadm entries can be add by creating keys starting with node-db.<entry.name>
+    #      # if doing CHAP
+    #      node-db.node.session.auth.authmethod: CHAP
+    #      node-db.node.session.auth.username: foo
+    #      node-db.node.session.auth.password: bar
+    #
+    #      # if doing mutual CHAP
+    #      node-db.node.session.auth.username_in: baz
+    #      node-db.node.session.auth.password_in: bar
+    #nodeStageSecretRef:
+    #  name: some name
+    #  namespace: some namespace
     volumeAttributes:
       portal: <ip:port>
       #portals: <ip:port>,<ip:port>,...

--- a/examples/node-manual-smb-pv.yaml
+++ b/examples/node-manual-smb-pv.yaml
@@ -9,9 +9,6 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  #nodeStageSecretRef:
-  #  name: some name
-  #  namespace: some namespace
   mountOptions:
     # creds can be entered into the node-stage-secret in the `mount_flags` key
     # the value should be: username=foo,password=bar
@@ -22,6 +19,9 @@ spec:
     readOnly: false
     fsType: cifs
     volumeHandle: unique-volumeid  # make sure it's a unique id in the cluster
+    #nodeStageSecretRef:
+    #  name: some name
+    #  namespace: some namespace
     volumeAttributes:
       server: host or ip
       share: someshare


### PR DESCRIPTION
Some of the examples show the `nodeStageSecretRef` key under root instead of the `csi.` key.