### PR TITLE
Enable loose coercing and add warning if the version is invalid

### DIFF
--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -183,7 +183,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const apiVersion = httpClient.getApiVersion();
     const zb = await this.getZetabyte();
     const truenasVersion = semver.coerce(
-      await httpApiClient.getSystemVersionMajorMinor()
+      await httpApiClient.getSystemVersionMajorMinor(), { loose: true }
     );
     const isScale = await httpApiClient.getIsScale();
 
@@ -265,6 +265,10 @@ class FreeNASApiDriver extends CsiBaseDriver {
                   break;
               }
 
+              if (!semver.valid(truenasVersion)) {
+                this.ctx.logger.warn("invalid truenas version, api compatibility might be broken");
+              }
+              
               if (isScale && semver.satisfies(truenasVersion, ">=23.10")) {
                 delete share.quiet;
                 delete share.nfs_quiet;

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -231,7 +231,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
     const apiVersion = httpClient.getApiVersion();
     const zb = await this.getZetabyte();
     const truenasVersion = semver.coerce(
-      await httpApiClient.getSystemVersionMajorMinor()
+      await httpApiClient.getSystemVersionMajorMinor(), { loose: true }
     );
     const isScale = await httpApiClient.getIsScale();
 
@@ -312,6 +312,10 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                     security: [],
                   };
                   break;
+              }
+
+              if (!semver.valid(truenasVersion)) {
+                this.ctx.logger.warn("invalid truenas version, api compatibility might be broken");
               }
 
               if (isScale && semver.satisfies(truenasVersion, ">=23.10")) {


### PR DESCRIPTION
As discussed in #365 the semver specification doesn't allow leading zeroes in versions, potentially causing api compatibility issues in some versions because the version checks fail when the corece returns null. Confirmed doing so in 24.04.

This PR enables the "loose" options when coercing and in the case of 24.04 the version is translated to 24.4.0. It also adds a warning if the version is invalid saying that the compatibility might be broken. Hopefully that should happen anymore though.. :) 

This is a pretty conservative approach, another option could be to assume a recent version and enable the latest API parameters by setting the truenas version to something like "999.999.999" if the version is invalid. 