### PR TITLE
Convert MOUNT_DEFAULT_TIMEOUT into integer

### DIFF
--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -10,7 +10,17 @@ const FINDMNT_COMMON_OPTIONS = [
   "--nofsroot", // prevents unwanted behavior with cifs volumes
 ];
 
-const DEFAULT_TIMEOUT = process.env.MOUNT_DEFAULT_TIMEOUT ? +process.env.MOUNT_DEFAULT_TIMEOUT : 3000;
+const DEFAULT_TIMEOUT = (() => {
+    const defaultValue = 30000;
+    if (process.env.MOUNT_DEFAULT_TIMEOUT) {
+        if (/^\d+$/.test(process.env.MOUNT_DEFAULT_TIMEOUT)) {
+            return parseInt(process.env.MOUNT_DEFAULT_TIMEOUT);
+        } else {
+            console.log("Invalid MOUNT_DEFAULT_TIMEOUT set: " + process.env.MOUNT_DEFAULT_TIMEOUT);
+        }
+    }
+    return defaultValue;
+})()
 
 class Mount {
   constructor(options = {}) {

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -10,7 +10,7 @@ const FINDMNT_COMMON_OPTIONS = [
   "--nofsroot", // prevents unwanted behavior with cifs volumes
 ];
 
-const DEFAULT_TIMEOUT = process.env.MOUNT_DEFAULT_TIMEOUT || 30000;
+const DEFAULT_TIMEOUT = process.env.MOUNT_DEFAULT_TIMEOUT ? +process.env.MOUNT_DEFAULT_TIMEOUT : 3000;
 
 class Mount {
   constructor(options = {}) {

--- a/src/utils/mount.js
+++ b/src/utils/mount.js
@@ -20,7 +20,7 @@ const DEFAULT_TIMEOUT = (() => {
         }
     }
     return defaultValue;
-})()
+})();
 
 class Mount {
   constructor(options = {}) {


### PR DESCRIPTION
Hit this error when trying to customize mount timeout. The timeout environment variable is not properly converted into an integer and thus the error occurred.

```json
{"host":"[REDACTED]","level":"error","message":"handler error - driver: ControllerZfsGenericDriver method: NodeGetVolumeStats error: RangeError [ERR_OUT_OF_RANGE]: The value of \"timeout\" is out of range. It must be an unsigned integer. Received '90000' RangeError [ERR_OUT_OF_RANGE]: The value of \"timeout\" is out of range. It must be an unsigned integer. Received '90000'\n    at validateTimeout (node:child_process:987:11)\n    at Object.spawn (node:child_process:755:3)\n    at /home/csi/app/src/utils/mount.js:412:44\n    at new Promise (<anonymous>)\n    at Mount.exec (/home/csi/app/src/utils/mount.js:411:12)\n    at Mount.pathIsMounted (/home/csi/app/src/utils/mount.js:100:28)\n    at Mount.isBindMountedBlockDevice (/home/csi/app/src/utils/mount.js:296:36)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async ControllerZfsGenericDriver.NodeGetVolumeStats (/home/csi/app/src/driver/index.js:3496:12)\n    at async requestHandlerProxy (/home/csi/app/bin/democratic-csi:222:18)","service":"democratic-csi","timestamp":"2024-10-07T14:18:38.308Z"}
```