### PR TITLE
Add proxy driver

### DIFF
--- a/src/driver/controller-proxy/index.js
+++ b/src/driver/controller-proxy/index.js
@@ -5,27 +5,52 @@ const yaml = require("js-yaml");
 
 // Some drivers will not work properly
 // zfs-local-ephemeral-inline is not supported
-// - !!! NodeUnpublishVolume does not have context to get driver
-// - I want to using secrets for NodePublishVolume
+// - NodePublishVolume needs this.options
+// - - Possible fix: Add whole config to node publish secret
+// - NodeUnpublishVolume does not have context to get driver
+// - - Possible fix: ???
 // zfs-local-* is not supported
 // - NodeGetInfo does not have context to get driver
-// - maybe we could move NodeGetInfo into CsiBaseDriver? 
+// - - Possible fix: move NodeGetInfo into CsiBaseDriver
 // local-hostpath is not supported
 // - NodeGetInfo does not have context to get driver
-// - maybe we could move NodeGetInfo into CsiBaseDriver? 
+// - - Possible fix: move NodeGetInfo into CsiBaseDriver
 // objectivefs is not supported
-// - I want to using secrets for NodeStageVolume (needs options in getDefaultObjectiveFSInstance)
+// - NodeStageVolume needs this.options in getDefaultObjectiveFSInstance
+// - - Possible fix: store objectivefs pool data in volume attributes
+// - - Possible fix: Add whole config to node stage secret
+//
+// [partially fixed] zfs-generic-* drivers use this.options.sshConnection in global registry
+// [partially fixed] freenas-api-* drivers use this.options.httpConnection in global registry
+// [partially fixed] freenas-* drivers use this.options.sshConnection in global registry
+// synology-* drivers use this.options.httpConnection in global registry
+// zfs-local-ephemeral-inline driver uses this.options.sshConnection and this.options.zfs in global registry
+// csi-proxy as a whole uses this.options
+// 
+// Generally: any global registry usage is a potential failure point
 //
 // There are some missing features:
 // - GetCapacity is not possible, there is no concept of unified storage for proxy
 // - ListVolumes is not possible, there is no concept of unified storage for proxy
-// - ControllerGetVolume is not possible without k8s access
+// - ControllerGetVolume is not possible without k8s access for more context
 //
-// TODO any reason to support VOLUME_MOUNT_GROUP for SMB?
-// TODO prevent volume cloning and snapshots?
-//      between storage classes?
-//      between drivers?
-//      enhance drivers to use zfs send?
+// Volume cloning and snapshots:
+// Works when both volumes have the same
+// - remote server
+// - parent dataset
+// - type of volume
+// volume_content_source field doesn't have anything except volume_id / snapshot_id
+// so it doesn't seem possible to even know that something doesn't match.
+// Even transfer between parent datasets on the same server would be difficult:
+// maybe you could be able to scan all volumes (and/or snapshots) on the system
+// for some custom dataset properties but it doesn't seem practical.
+//
+// Things could get better if volume_id somehow identified the server and the dataset.
+// Naive way: make it server.address/full/dataset/path
+// Server will then need to get access to server.address via some global config instead of using storage class secrets
+// It would require significant changes to how application settings are handled.
+//
+// TODO support VOLUME_MOUNT_GROUP for SMB?
 class CsiProxyDriver extends CsiBaseDriver {
   constructor(ctx, options) {
     super(...arguments);
@@ -83,7 +108,7 @@ class CsiProxyDriver extends CsiBaseDriver {
       if (semver.satisfies(this.ctx.csiVersion, ">=1.3.0")) {
         options.service.controller.capabilities.rpc.push(
           //"VOLUME_CONDITION",
-          "GET_VOLUME"
+          // "GET_VOLUME"
         );
       }
 
@@ -162,6 +187,9 @@ class CsiProxyDriver extends CsiBaseDriver {
       "zfs-local-zvol",
       "objectivefs",
       "local-hostpath",
+      "synology-nfs",
+      "synology-smb",
+      "synology-iscsi",
     ];
     if (unsupportedDrivers.includes(mergedOptions.driver)) {
       throw "proxy is not supported for driver: " + mergedOptions.driver;

--- a/src/driver/controller-proxy/index.js
+++ b/src/driver/controller-proxy/index.js
@@ -3,6 +3,29 @@ const semver = require("semver");
 const { CsiBaseDriver } = require("../index");
 const yaml = require("js-yaml");
 
+// Some drivers will not work properly
+// zfs-local-ephemeral-inline is not supported
+// - !!! NodeUnpublishVolume does not have context to get driver
+// - I want to using secrets for NodePublishVolume
+// zfs-local-* is not supported
+// - NodeGetInfo does not have context to get driver
+// - maybe we could move NodeGetInfo into CsiBaseDriver? 
+// local-hostpath is not supported
+// - NodeGetInfo does not have context to get driver
+// - maybe we could move NodeGetInfo into CsiBaseDriver? 
+// objectivefs is not supported
+// - I want to using secrets for NodeStageVolume (needs options in getDefaultObjectiveFSInstance)
+//
+// There are some missing features:
+// - GetCapacity is not possible, there is no concept of unified storage for proxy
+// - ListVolumes is not possible, there is no concept of unified storage for proxy
+// - ControllerGetVolume is not possible without k8s access
+//
+// TODO any reason to support VOLUME_MOUNT_GROUP for SMB?
+// TODO prevent volume cloning and snapshots?
+//      between storage classes?
+//      between drivers?
+//      enhance drivers to use zfs send?
 class CsiProxyDriver extends CsiBaseDriver {
   constructor(ctx, options) {
     super(...arguments);
@@ -133,6 +156,16 @@ class CsiProxyDriver extends CsiBaseDriver {
 
   createRealDriver(call) {
     const mergedOptions = this.mergeOptions(call)
+    const unsupportedDrivers = [
+      "zfs-local-ephemeral-inline",
+      "zfs-local-dataset",
+      "zfs-local-zvol",
+      "objectivefs",
+      "local-hostpath",
+    ];
+    if (unsupportedDrivers.includes(mergedOptions.driver)) {
+      throw "proxy is not supported for driver: " + mergedOptions.driver;
+    }
     const realDriver = this.ctx.factory(this.ctx, mergedOptions);
     if (realDriver.constructor.name == this.constructor.name) {
       throw "cyclic dependency: proxy on proxy";
@@ -140,18 +173,6 @@ class CsiProxyDriver extends CsiBaseDriver {
     this.ctx.logger.debug("using driver %s", realDriver.constructor.name);
     return realDriver;
   }
-
-  // async GetPluginInfo(call) {
-  //   return super.GetPluginInfo(call);
-  // }
-
-  // async GetPluginCapabilities(call) {
-  //   return super.GetPluginCapabilities(call);
-  // }
-
-  // async Probe(call) {
-  //   return super.Probe(call);
-  // }
 
   async CreateVolume(call) {
     return this.createRealDriver(call).CreateVolume(call);
@@ -161,28 +182,9 @@ class CsiProxyDriver extends CsiBaseDriver {
     return this.createRealDriver(call).DeleteVolume(call);
   }
 
-  // async ControllerGetCapabilities(call) {
-  //   return super.ControllerGetCapabilities();
-  // }
-
   async ControllerExpandVolume(call) {
     return this.createRealDriver(call).ControllerExpandVolume(call);
   }
-
-  // GetCapacityRequest does not have secrets
-  // async GetCapacity(call) {
-  //   return this.createDriver(call).GetCapacity(call);
-  // }
-
-  // ControllerGetVolumeRequest does not have secrets
-  // async ControllerGetVolume(call) {
-  //   return super.ControllerGetVolume();
-  // }
-
-  // ListVolumesRequest does not have secrets
-  // async ListVolumes(call) {
-  //   return super.ListVolumes();
-  // }
 
   async ListSnapshots(call) {
     return this.createRealDriver(call).ListSnapshots(call);
@@ -199,44 +201,6 @@ class CsiProxyDriver extends CsiBaseDriver {
   async ValidateVolumeCapabilities(call) {
     return this.createRealDriver(call).ValidateVolumeCapabilities(call);
   }
-
-  // async NodeGetCapabilities(call) {
-  //   return super.NodeGetCapabilities(call);
-  // }
-
-  // TODO controller-zfs-local needs this
-  // async NodeGetInfo(call) {
-  //   return super.NodeGetInfo(call);
-  // }
-
-  async NodeStageVolume(call) {
-    return this.createRealDriver(call).NodeStageVolume(call);
-  }
-
-  // NodeUnstageVolumeRequest does not have secrets
-  // async NodeUnstageVolume(call) {
-  //   return this.createRealDriver(call).NodeUnstageVolume(call);
-  // }
-
-  async NodePublishVolume(call) {
-    return this.createRealDriver(call).NodePublishVolume(call);
-  }
-
-  // NodeUnpublishVolumeRequest does not have secrets
-  // TODO zfs-local-ephemeral seems to use this
-  // async NodeUnpublishVolume(call) {
-  //   return this.createRealDriver(call).NodeUnpublishVolume(call);
-  // }
-
-  // NodeGetVolumeStatsRequest does not have secrets
-  // async NodeGetVolumeStats(call) {
-  //   return this.createDriver(call).NodeGetVolumeStats(call);
-  // }
-
-  // NodeExpandVolumeRequest has field for secrets but external-resizer does not populate it
-  // async NodeExpandVolume(call) {
-  //   return this.createRealDriver(call).NodeExpandVolume(call);
-  // }
 }
 
 module.exports.CsiProxyDriver = CsiProxyDriver;

--- a/src/driver/controller-proxy/index.js
+++ b/src/driver/controller-proxy/index.js
@@ -1,0 +1,242 @@
+const _ = require("lodash");
+const semver = require("semver");
+const { CsiBaseDriver } = require("../index");
+const yaml = require("js-yaml");
+
+class CsiProxyDriver extends CsiBaseDriver {
+  constructor(ctx, options) {
+    super(...arguments);
+    options = options || {};
+    options.service = options.service || {};
+    options.service.identity = options.service.identity || {};
+    options.service.controller = options.service.controller || {};
+    options.service.node = options.service.node || {};
+
+    options.service.identity.capabilities =
+      options.service.identity.capabilities || {};
+
+    options.service.controller.capabilities =
+      options.service.controller.capabilities || {};
+
+    options.service.node.capabilities = options.service.node.capabilities || {};
+
+    if (!("service" in options.service.identity.capabilities)) {
+      this.ctx.logger.debug("setting default identity service caps");
+
+      options.service.identity.capabilities.service = [
+        //"UNKNOWN",
+        "CONTROLLER_SERVICE",
+        //"VOLUME_ACCESSIBILITY_CONSTRAINTS"
+      ];
+    }
+
+    if (!("volume_expansion" in options.service.identity.capabilities)) {
+      this.ctx.logger.debug("setting default identity volume_expansion caps");
+
+      options.service.identity.capabilities.volume_expansion = [
+        //"UNKNOWN",
+        "ONLINE",
+        //"OFFLINE"
+      ];
+    }
+
+    if (!("rpc" in options.service.controller.capabilities)) {
+      this.ctx.logger.debug("setting default controller caps");
+
+      options.service.controller.capabilities.rpc = [
+        //"UNKNOWN",
+        "CREATE_DELETE_VOLUME",
+        //"PUBLISH_UNPUBLISH_VOLUME",
+        //"LIST_VOLUMES_PUBLISHED_NODES",
+        // "LIST_VOLUMES",
+        // "GET_CAPACITY",
+        "CREATE_DELETE_SNAPSHOT",
+        "LIST_SNAPSHOTS",
+        "CLONE_VOLUME",
+        //"PUBLISH_READONLY",
+        "EXPAND_VOLUME",
+      ];
+
+      if (semver.satisfies(this.ctx.csiVersion, ">=1.3.0")) {
+        options.service.controller.capabilities.rpc.push(
+          //"VOLUME_CONDITION",
+          "GET_VOLUME"
+        );
+      }
+
+      if (semver.satisfies(this.ctx.csiVersion, ">=1.5.0")) {
+        options.service.controller.capabilities.rpc.push(
+          "SINGLE_NODE_MULTI_WRITER"
+        );
+      }
+    }
+
+    if (!("rpc" in options.service.node.capabilities)) {
+      this.ctx.logger.debug("setting default node caps");
+      options.service.node.capabilities.rpc = [
+        //"UNKNOWN",
+        "STAGE_UNSTAGE_VOLUME",
+        "GET_VOLUME_STATS",
+        "EXPAND_VOLUME",
+        //"VOLUME_CONDITION",
+      ];
+
+      if (semver.satisfies(this.ctx.csiVersion, ">=1.3.0")) {
+        //options.service.node.capabilities.rpc.push("VOLUME_CONDITION");
+      }
+
+      if (semver.satisfies(this.ctx.csiVersion, ">=1.5.0")) {
+        options.service.node.capabilities.rpc.push("SINGLE_NODE_MULTI_WRITER");
+        /**
+         * This is for volumes that support a mount time gid such as smb or fat
+         */
+        //options.service.node.capabilities.rpc.push("VOLUME_MOUNT_GROUP"); // in k8s is sent in as the security context fsgroup
+      }
+    }
+
+    // if (options.fallbackDriver) {
+    //   const optionsClone = structuredClone(value);
+    //   optionsClone.driver = options.fallbackDriver;
+    //   this.fallbackDriver = ctx.factory(ctx, optionsClone);
+    // }
+  }
+
+  getOptionsFromSecrets(call) {
+    const prefix = "config-";
+    let names = Object.keys(call.request.secrets).sort();
+    let res = null;
+    for (const i in names) {
+      const key = names[i];
+      if (typeof key !== 'string' || !key.startsWith(prefix)) {
+        continue;
+      }
+      const secret = call.request.secrets[key];
+      try {
+        res = _.merge(res, yaml.load(secret));
+      } catch (e) {
+        console.log("failed parsing secret " + key, e);
+        throw e;
+      }
+    }
+    return res;
+  }
+
+  mergeOptions(call) {
+    const options = this.getOptionsFromSecrets(call);
+    const mergedOptions = structuredClone(this.options);
+    _.merge(mergedOptions, options);
+    if (!mergedOptions.driver) {
+      throw "real driver is missing from config";
+    }
+    return mergedOptions;
+  }
+
+  createRealDriver(call) {
+    const mergedOptions = this.mergeOptions(call)
+    const realDriver = this.ctx.factory(this.ctx, mergedOptions);
+    if (realDriver.constructor.name == this.constructor.name) {
+      throw "cyclic dependency: proxy on proxy";
+    }
+    this.ctx.logger.debug("using driver %s", realDriver.constructor.name);
+    return realDriver;
+  }
+
+  // async GetPluginInfo(call) {
+  //   return super.GetPluginInfo(call);
+  // }
+
+  // async GetPluginCapabilities(call) {
+  //   return super.GetPluginCapabilities(call);
+  // }
+
+  // async Probe(call) {
+  //   return super.Probe(call);
+  // }
+
+  async CreateVolume(call) {
+    return this.createRealDriver(call).CreateVolume(call);
+  }
+
+  async DeleteVolume(call) {
+    return this.createRealDriver(call).DeleteVolume(call);
+  }
+
+  // async ControllerGetCapabilities(call) {
+  //   return super.ControllerGetCapabilities();
+  // }
+
+  async ControllerExpandVolume(call) {
+    return this.createRealDriver(call).ControllerExpandVolume(call);
+  }
+
+  // GetCapacityRequest does not have secrets
+  // async GetCapacity(call) {
+  //   return this.createDriver(call).GetCapacity(call);
+  // }
+
+  // ControllerGetVolumeRequest does not have secrets
+  // async ControllerGetVolume(call) {
+  //   return super.ControllerGetVolume();
+  // }
+
+  // ListVolumesRequest does not have secrets
+  // async ListVolumes(call) {
+  //   return super.ListVolumes();
+  // }
+
+  async ListSnapshots(call) {
+    return this.createRealDriver(call).ListSnapshots(call);
+  }
+
+  async CreateSnapshot(call) {
+    return this.createRealDriver(call).CreateSnapshot(call);
+  }
+
+  async DeleteSnapshot(call) {
+    return this.createRealDriver(call).DeleteSnapshot(call);
+  }
+
+  async ValidateVolumeCapabilities(call) {
+    return this.createRealDriver(call).ValidateVolumeCapabilities(call);
+  }
+
+  // async NodeGetCapabilities(call) {
+  //   return super.NodeGetCapabilities(call);
+  // }
+
+  // TODO controller-zfs-local needs this
+  // async NodeGetInfo(call) {
+  //   return super.NodeGetInfo(call);
+  // }
+
+  async NodeStageVolume(call) {
+    return this.createRealDriver(call).NodeStageVolume(call);
+  }
+
+  // NodeUnstageVolumeRequest does not have secrets
+  // async NodeUnstageVolume(call) {
+  //   return this.createRealDriver(call).NodeUnstageVolume(call);
+  // }
+
+  async NodePublishVolume(call) {
+    return this.createRealDriver(call).NodePublishVolume(call);
+  }
+
+  // NodeUnpublishVolumeRequest does not have secrets
+  // TODO zfs-local-ephemeral seems to use this
+  // async NodeUnpublishVolume(call) {
+  //   return this.createRealDriver(call).NodeUnpublishVolume(call);
+  // }
+
+  // NodeGetVolumeStatsRequest does not have secrets
+  // async NodeGetVolumeStats(call) {
+  //   return this.createDriver(call).NodeGetVolumeStats(call);
+  // }
+
+  // NodeExpandVolumeRequest has field for secrets but external-resizer does not populate it
+  // async NodeExpandVolume(call) {
+  //   return this.createRealDriver(call).NodeExpandVolume(call);
+  // }
+}
+
+module.exports.CsiProxyDriver = CsiProxyDriver;

--- a/src/driver/controller-synology/index.js
+++ b/src/driver/controller-synology/index.js
@@ -128,7 +128,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       case "synology-iscsi":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 
@@ -141,7 +141,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       case "synology-iscsi":
         return "iscsi";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -71,7 +71,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
       case "zfs-generic-nvmeof":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -15,7 +15,7 @@ const NVMEOF_ASSETS_NAME_PROPERTY_NAME = "democratic-csi:nvmeof_assets_name";
 const __REGISTRY_NS__ = "ControllerZfsGenericDriver";
 class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
   getExecClient() {
-    return registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
+    return registry.get(`${__REGISTRY_NS__}:exec_client:${this.options.sshConnection.username}@${this.options.sshConnection.host}:${this.options.sshConnection.port}`, () => {
       if (this.options.sshConnection) {
         return new SshClient({
           logger: this.ctx.logger,
@@ -30,7 +30,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
   }
 
   async getZetabyte() {
-    return registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
+    return registry.getAsync(`${__REGISTRY_NS__}:zb:${this.options.sshConnection.username}@${this.options.sshConnection.host}:${this.options.sshConnection.port}:${JSON.stringify(this.options.zfs.cli)}`, async () => {
       const execClient = this.getExecClient();
       const options = {};
       if (this.options.sshConnection) {

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -87,7 +87,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
       case "zfs-local-zvol":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/factory.js
+++ b/src/driver/factory.js
@@ -15,9 +15,13 @@ const { ControllerLustreClientDriver } = require("./controller-lustre-client");
 const { ControllerObjectiveFSDriver } = require("./controller-objectivefs");
 const { ControllerSynologyDriver } = require("./controller-synology");
 const { NodeManualDriver } = require("./node-manual");
+const { CsiProxyDriver } = require("./controller-proxy");
 
 function factory(ctx, options) {
+  ctx.factory = factory;
   switch (options.driver) {
+    case "proxy":
+      return new CsiProxyDriver(ctx, options);
     case "freenas-nfs":
     case "freenas-smb":
     case "freenas-iscsi":

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -1975,7 +1975,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       case "truenas-api-iscsi":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 
@@ -1991,7 +1991,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       case "truenas-api-iscsi":
         return "iscsi";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -2017,7 +2017,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
   }
 
   async getHttpClient() {
-    return registry.get(`${__REGISTRY_NS__}:http_client`, () => {
+    return registry.get(`${__REGISTRY_NS__}:http_client:${this.options.httpConnection.username}@${this.options.httpConnection.host}:${this.options.httpConnection.port}`, () => {
       const client = new HttpClient(this.options.httpConnection);
       client.logger = this.ctx.logger;
       client.setApiVersion(2); // requires version 2
@@ -2034,7 +2034,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
   }
 
   async getTrueNASHttpApiClient() {
-    return registry.getAsync(`${__REGISTRY_NS__}:api_client`, async () => {
+    return registry.getAsync(`${__REGISTRY_NS__}:api_client:${this.options.httpConnection.username}@${this.options.httpConnection.host}:${this.options.httpConnection.port}`, async () => {
       const httpClient = await this.getHttpClient();
       return new TrueNASApiClient(httpClient, this.ctx.cache);
     });

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -105,7 +105,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
       case "truenas-iscsi":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 
@@ -161,7 +161,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
       case "truenas-iscsi":
         return "iscsi";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -57,7 +57,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
   }
 
   getExecClient() {
-    return registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
+    return registry.get(`${__REGISTRY_NS__}:exec_client:${this.options.sshConnection.username}@${this.options.sshConnection.host}:${this.options.sshConnection.port}`, () => {
       return new SshClient({
         logger: this.ctx.logger,
         connection: this.options.sshConnection,
@@ -66,7 +66,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
   }
 
   async getZetabyte() {
-    return registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
+    return registry.getAsync(`${__REGISTRY_NS__}:zb:${this.options.sshConnection.username}@${this.options.sshConnection.host}:${this.options.sshConnection.port}:${JSON.stringify(this.options.zfs.cli)}`, async () => {
       const sshClient = this.getExecClient();
       const options = {};
       options.executor = new ZfsSshProcessManager(sshClient);


### PR DESCRIPTION
I have quite a few storage classes. I have 2 Truenas systems, and a plain Debian NAS. So I have something like 6 or so storage classes.
Currently democratic-csi can only hold one config per instance. Meaning, each one of my storage classes needs a separate deployment. One time I looked at my ~40 pods of democratic-csi controllers and nodes, and had a though that maybe I'm doing something wrong with my life. It just must be possible to specify config in storage class instead of creating a new deployment for each storage class.
So, it turns out, there is! I figured out you could just use parameters like `csi.storage.k8s.io/provisioner-secret-name` and then `external-provisioner` and other components will fill in additional config without a need to manually hook to k8s API. I didn't even almost require any changes to the existing code. It seems like similar secrets also can be specified in other container orchestration systems.
However, later I discovered a few issues, which may require extensive changes to the existing code to be fixed.

Disclaimer: this code is not ready to merge. It is not tested properly, it isn't even finished. But it works in a few limited scenarios.
I create this pull request to get feedback. If it is interesting for someone, then maybe I'll finish it.

What I did:
I created a new `proxy` driver. When it gets a new request, it looks up `call.request.secrets` for `config-*` files. It then creates the real driver specified in this config and redirects the call into it.
In the simple case the main program config will contain only `driver: proxy` line, and then the rest of the config will be 100% identical to what democratic-csi currently requires, and be supplied via `csi.storage.k8s.io/provisioner-secret-name`. Though it can be customized to be less repetitive via config merges.
This only affects `Controller*` methods. `Node*` methods seem to be generic enough to work with any driver.
All "local" drivers would need additional changes to be supported.

The issues:
1. Currently democratic-csi uses global `registry` to cache all the connection components.
It worked fine when I used, for example, nfs and nvmeof to the same server. Of when I used `freenas-api-nfs` and `zfs-generic-nfs` because they don't share registry values.
But it was impossible to use 2 `freenas-api-nfs` to connect to 2 different servers.
As a band-aid solution I added server address to registry key, to avoid collisions. But if server address is the same, but some other options are different, there will still be collisions.
I could solve this by using `JSON.stringify(this.options)` as a registry key, but I don't think this is _good_ solution.
In my opinion, the right solution would be to stop using global registry altogether. I think many values could just be cached in local object fields. If registry is required, local registry could be used. But, maybe the `JSON.stringify(this.options)` could be used to cache drivers in the proxy.

2. Volume cloning and snapshot restore don't generally work between storage classes. They work fine when using the same storage class, but democratic-csi just doesn't know what to do when source data is in a different storage class.
It would be very cool if democratic-csi were be able to use zfs-send/zfs-receive. I think it wouldn't work non-zfs drivers but it would still be cool. But there is no info about source except for `volume_id` / `snapshot_id`.
I thought of ways to put context info into the id string itself. But the limited field length concerns me.
For example, this is how `volume_id` looks in `nfs-csi` driver:
`server.address#path/to/share#pvc-name#pv-name#retain`