### PR TITLE
set script configshell_fb version to 1.1.30

### DIFF
--- a/contrib/scale-nvmet-start.sh
+++ b/contrib/scale-nvmet-start.sh
@@ -84,7 +84,7 @@ install_nvmetcli() {
   python3 setup.py install --install-scripts=${HOME}/.local/bin
 
   # install to root home dir
-  pip install configshell_fb
+  pip install configshell_fb==1.1.30
 
   # remove source
   cd "${SCRIPTDIR}"


### PR DESCRIPTION
The default latest version of configshell_fb (2.0.0) causes the following error:
```
Traceback (most recent call last):
  File "/root/.local/bin/nvmetcli", line 4, in <module>
    __import__('pkg_resources').run_script('nvmetcli==0.8', 'nvmetcli')
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 708, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1528, in run_script
    exec(script_code, namespace, namespace)
  File "/root/nvmet-venv/lib/python3.11/site-packages/nvmetcli-0.8-py3.11.egg/EGG-INFO/scripts/nvmetcli", line 36, in <module>
AttributeError: module 'configshell_fb' has no attribute 'node'
```
