### PR TITLE
refactor: stop using global variable for cache registry

### DIFF
--- a/bin/democratic-csi
+++ b/bin/democratic-csi
@@ -140,10 +140,13 @@ const csi = protoDescriptor.csi.v1;
 
 logger.info("initializing csi driver: %s", options.driver);
 
+const { Registry } = require("../src/utils/registry");
+let globalRegistry = new Registry();
+
 let driver;
 try {
   driver = require("../src/driver/factory").factory(
-    { logger, args, cache, package, csiVersion },
+    { logger, args, cache, package, csiVersion, registry: globalRegistry },
     options
   );
 } catch (err) {

--- a/src/driver/controller-client-common/index.js
+++ b/src/driver/controller-client-common/index.js
@@ -7,7 +7,6 @@ const fse = require("fs-extra");
 const Kopia = require("../../utils/kopia").Kopia;
 const os = require("os");
 const path = require("path");
-const registry = require("../../utils/registry");
 const Restic = require("../../utils/restic").Restic;
 const semver = require("semver");
 
@@ -458,7 +457,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
   async getResticClient() {
     const driver = this;
 
-    return registry.get(`${__REGISTRY_NS__}:restic`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:restic`, () => {
       const config_key = driver.getConfigKey();
 
       const restic_env = _.get(
@@ -491,7 +490,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
   async getKopiaClient() {
     const driver = this;
 
-    return registry.getAsync(`${__REGISTRY_NS__}:kopia`, async () => {
+    return this.ctx.registry.getAsync(`${__REGISTRY_NS__}:kopia`, async () => {
       const config_key = driver.getConfigKey();
 
       const kopia_env = _.get(

--- a/src/driver/controller-objectivefs/index.js
+++ b/src/driver/controller-objectivefs/index.js
@@ -3,7 +3,6 @@ const { CsiBaseDriver } = require("../index");
 const { GrpcError, grpc } = require("../../utils/grpc");
 const GeneralUtils = require("../../utils/general");
 const { ObjectiveFS } = require("../../utils/objectivefs");
-const registry = require("../../utils/registry");
 const semver = require("semver");
 const uuidv4 = require("uuid").v4;
 
@@ -105,7 +104,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
 
   async getObjectiveFSClient() {
     const driver = this;
-    return registry.getAsync(
+    return this.ctx.registry.getAsync(
       `${__REGISTRY_NS__}:objectivefsclient`,
       async () => {
         const options = {};

--- a/src/driver/controller-synology/http/index.js
+++ b/src/driver/controller-synology/http/index.js
@@ -3,7 +3,6 @@ const http = require("http");
 const https = require("https");
 const { axios_request, stringify } = require("../../../utils/general");
 const Mutex = require("async-mutex").Mutex;
-const registry = require("../../../utils/registry");
 const { GrpcError, grpc } = require("../../../utils/grpc");
 
 const USER_AGENT = "democratic-csi";
@@ -95,7 +94,7 @@ class SynologyHttpClient {
   }
 
   getHttpAgent() {
-    return registry.get(`${__REGISTRY_NS__}:http_agent`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:http_agent`, () => {
       return new http.Agent({
         keepAlive: true,
         maxSockets: Infinity,
@@ -105,7 +104,7 @@ class SynologyHttpClient {
   }
 
   getHttpsAgent() {
-    return registry.get(`${__REGISTRY_NS__}:https_agent`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:https_agent`, () => {
       return new https.Agent({
         keepAlive: true,
         maxSockets: Infinity,

--- a/src/driver/controller-synology/index.js
+++ b/src/driver/controller-synology/index.js
@@ -3,7 +3,6 @@ const { CsiBaseDriver } = require("../index");
 const GeneralUtils = require("../../utils/general");
 const { GrpcError, grpc } = require("../../utils/grpc");
 const Handlebars = require("handlebars");
-const registry = require("../../utils/registry");
 const SynologyHttpClient = require("./http").SynologyHttpClient;
 const semver = require("semver");
 const yaml = require("js-yaml");
@@ -115,7 +114,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
   }
 
   async getHttpClient() {
-    return registry.get(`${__REGISTRY_NS__}:http_client`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:http_client`, () => {
       return new SynologyHttpClient(this.options.httpConnection);
     });
   }

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -2,7 +2,6 @@ const _ = require("lodash");
 const { ControllerZfsBaseDriver } = require("../controller-zfs");
 const { GrpcError, grpc } = require("../../utils/grpc");
 const GeneralUtils = require("../../utils/general");
-const registry = require("../../utils/registry");
 const LocalCliExecClient =
   require("../../utils/zfs_local_exec_client").LocalCliClient;
 const SshClient = require("../../utils/zfs_ssh_exec_client").SshClient;
@@ -15,7 +14,7 @@ const NVMEOF_ASSETS_NAME_PROPERTY_NAME = "democratic-csi:nvmeof_assets_name";
 const __REGISTRY_NS__ = "ControllerZfsGenericDriver";
 class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
   getExecClient() {
-    return registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
       if (this.options.sshConnection) {
         return new SshClient({
           logger: this.ctx.logger,
@@ -30,7 +29,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
   }
 
   async getZetabyte() {
-    return registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
+    return this.ctx.registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
       const execClient = this.getExecClient();
       const options = {};
       if (this.options.sshConnection) {

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -4,7 +4,6 @@ const { GrpcError, grpc } = require("../../utils/grpc");
 const GeneralUtils = require("../../utils/general");
 const LocalCliExecClient =
   require("../../utils/zfs_local_exec_client").LocalCliClient;
-const registry = require("../../utils/registry");
 const { Zetabyte } = require("../../utils/zfs");
 
 const ZFS_ASSET_NAME_PROPERTY_NAME = "zfs_asset_name";
@@ -33,7 +32,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
   }
 
   getExecClient() {
-    return registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
       return new LocalCliExecClient({
         logger: this.ctx.logger,
       });
@@ -41,7 +40,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
   }
 
   async getZetabyte() {
-    return registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
+    return this.ctx.registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
       const execClient = this.getExecClient();
 
       const options = {};

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -4,7 +4,6 @@ const { CsiBaseDriver } = require("../index");
 const HttpClient = require("./http").Client;
 const TrueNASApiClient = require("./http/api").Api;
 const { Zetabyte } = require("../../utils/zfs");
-const registry = require("../../utils/registry");
 const GeneralUtils = require("../../utils/general");
 
 const Handlebars = require("handlebars");
@@ -156,7 +155,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    * @returns
    */
   async getZetabyte() {
-    return registry.get(`${__REGISTRY_NS__}:zb`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:zb`, () => {
       return new Zetabyte({
         executor: {
           spawn: function () {
@@ -2017,7 +2016,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
   }
 
   async getHttpClient() {
-    return registry.get(`${__REGISTRY_NS__}:http_client`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:http_client`, () => {
       const client = new HttpClient(this.options.httpConnection);
       client.logger = this.ctx.logger;
       client.setApiVersion(2); // requires version 2
@@ -2034,7 +2033,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
   }
 
   async getTrueNASHttpApiClient() {
-    return registry.getAsync(`${__REGISTRY_NS__}:api_client`, async () => {
+    return this.ctx.registry.getAsync(`${__REGISTRY_NS__}:api_client`, async () => {
       const httpClient = await this.getHttpClient();
       return new TrueNASApiClient(httpClient, this.ctx.cache);
     });

--- a/src/driver/freenas/http/api.js
+++ b/src/driver/freenas/http/api.js
@@ -1,4 +1,4 @@
-const registry = require("../../../utils/registry");
+
 const { sleep, stringify } = require("../../../utils/general");
 const { Zetabyte } = require("../../../utils/zfs");
 
@@ -22,7 +22,7 @@ class Api {
    * @returns
    */
   async getZetabyte() {
-    return registry.get(`${__REGISTRY_NS__}:zb`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:zb`, () => {
       return new Zetabyte({
         executor: {
           spawn: function () {

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -1,7 +1,6 @@
 const _ = require("lodash");
 const { ControllerZfsBaseDriver } = require("../controller-zfs");
 const { GrpcError, grpc } = require("../../utils/grpc");
-const registry = require("../../utils/registry");
 const SshClient = require("../../utils/zfs_ssh_exec_client").SshClient;
 const HttpClient = require("./http").Client;
 const TrueNASApiClient = require("./http/api").Api;
@@ -57,7 +56,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
   }
 
   getExecClient() {
-    return registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
       return new SshClient({
         logger: this.ctx.logger,
         connection: this.options.sshConnection,
@@ -66,7 +65,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
   }
 
   async getZetabyte() {
-    return registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
+    return this.ctx.registry.getAsync(`${__REGISTRY_NS__}:zb`, async () => {
       const sshClient = this.getExecClient();
       const options = {};
       options.executor = new ZfsSshProcessManager(sshClient);
@@ -126,7 +125,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
   async getHttpClient(autoDetectVersion = true) {
     const autodetectkey = autoDetectVersion === true ? 1 : 0;
-    return registry.getAsync(
+    return this.ctx.registry.getAsync(
       `${__REGISTRY_NS__}:http_client:autoDetectVersion_${autodetectkey}`,
       async () => {
         const client = new HttpClient(this.options.httpConnection);
@@ -143,7 +142,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
   }
 
   async getTrueNASHttpApiClient() {
-    return registry.getAsync(`${__REGISTRY_NS__}:api_client`, async () => {
+    return this.ctx.registry.getAsync(`${__REGISTRY_NS__}:api_client`, async () => {
       const httpClient = await this.getHttpClient();
       return new TrueNASApiClient(httpClient, this.ctx.cache);
     });

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -12,7 +12,6 @@ const { OneClient } = require("../utils/oneclient");
 const { Filesystem } = require("../utils/filesystem");
 const { ISCSI } = require("../utils/iscsi");
 const { NVMEoF } = require("../utils/nvmeof");
-const registry = require("../utils/registry");
 const semver = require("semver");
 const GeneralUtils = require("../utils/general");
 const { Zetabyte } = require("../utils/zfs");
@@ -111,7 +110,7 @@ class CsiBaseDriver {
    * @returns Filesystem
    */
   getDefaultFilesystemInstance() {
-    return registry.get(
+    return this.ctx.registry.get(
       `${__REGISTRY_NS__}:default_filesystem_instance`,
       () => {
         return new Filesystem();
@@ -125,7 +124,7 @@ class CsiBaseDriver {
    * @returns Mount
    */
   getDefaultMountInstance() {
-    return registry.get(`${__REGISTRY_NS__}:default_mount_instance`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:default_mount_instance`, () => {
       const filesystem = this.getDefaultFilesystemInstance();
       return new Mount({ filesystem });
     });
@@ -137,7 +136,7 @@ class CsiBaseDriver {
    * @returns ISCSI
    */
   getDefaultISCSIInstance() {
-    return registry.get(`${__REGISTRY_NS__}:default_iscsi_instance`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:default_iscsi_instance`, () => {
       return new ISCSI();
     });
   }
@@ -149,13 +148,13 @@ class CsiBaseDriver {
    */
   getDefaultNVMEoFInstance() {
     const driver = this;
-    return registry.get(`${__REGISTRY_NS__}:default_nvmeof_instance`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:default_nvmeof_instance`, () => {
       return new NVMEoF({ logger: driver.ctx.logger });
     });
   }
 
   getDefaultZetabyteInstance() {
-    return registry.get(`${__REGISTRY_NS__}:default_zb_instance`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:default_zb_instance`, () => {
       return new Zetabyte({
         idempotent: true,
         paths: {
@@ -177,14 +176,14 @@ class CsiBaseDriver {
   }
 
   getDefaultOneClientInstance() {
-    return registry.get(`${__REGISTRY_NS__}:default_oneclient_instance`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:default_oneclient_instance`, () => {
       return new OneClient();
     });
   }
 
   getDefaultObjectiveFSInstance() {
     const driver = this;
-    return registry.get(
+    return this.ctx.registry.get(
       `${__REGISTRY_NS__}:default_objectivefs_instance`,
       () => {
         return new ObjectiveFS({
@@ -199,7 +198,7 @@ class CsiBaseDriver {
    * @returns CsiProxyClient
    */
   getDefaultCsiProxyClientInstance() {
-    return registry.get(`${__REGISTRY_NS__}:default_csi_proxy_instance`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:default_csi_proxy_instance`, () => {
       const options = {};
       options.services = _.get(this.options, "node.csiProxy.services", {});
       return new CsiProxyClient(options);
@@ -207,7 +206,7 @@ class CsiBaseDriver {
   }
 
   getDefaultKubernetsConfigInstance() {
-    return registry.get(
+    return this.ctx.registry.get(
       `${__REGISTRY_NS__}:default_kubernetes_config_instance`,
       () => {
         const kc = new k8s.KubeConfig();

--- a/src/driver/zfs-local-ephemeral-inline/index.js
+++ b/src/driver/zfs-local-ephemeral-inline/index.js
@@ -2,7 +2,6 @@ const fs = require("fs");
 const { CsiBaseDriver } = require("../index");
 const { GrpcError, grpc } = require("../../utils/grpc");
 const { Filesystem } = require("../../utils/filesystem");
-const registry = require("../../utils/registry");
 const semver = require("semver");
 const SshClient = require("../../utils/zfs_ssh_exec_client").SshClient;
 const { Zetabyte, ZfsSshProcessManager } = require("../../utils/zfs");
@@ -125,7 +124,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
   }
 
   getSshClient() {
-    return registry.get(`${__REGISTRY_NS__}:ssh_client`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:ssh_client`, () => {
       return new SshClient({
         logger: this.ctx.logger,
         connection: this.options.sshConnection,
@@ -134,7 +133,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
   }
 
   getZetabyte() {
-    return registry.get(`${__REGISTRY_NS__}:zb`, () => {
+    return this.ctx.registry.get(`${__REGISTRY_NS__}:zb`, () => {
       let sshClient;
       let executor;
       if (this.options.sshConnection) {

--- a/src/utils/registry.js
+++ b/src/utils/registry.js
@@ -48,6 +48,4 @@ class Registry {
   }
 }
 
-const registry = new Registry();
-
-module.exports = registry;
+module.exports.Registry = Registry;


### PR DESCRIPTION
This PR effectively simply changes `registry.get(...)` to `this.ctx.registry.get(...)` everywhere.

This is a simple refactor.
This will help https://github.com/democratic-csi/democratic-csi/pull/433 and similar initiatives which suffer from cache key collisions.

I think, it may be better to remove registry completely. But when I tried to do it, it seemed much harder to review changes, so I decided to leave it to possible future refactors.

I think this change is simple enough to avoid any mistakes.
I tested this with truenas-api and zfs-generic drivers, and it seems to work fine, but I don't have local setup for any other drivers.