### PR TITLE
Fix driver name reporting in exceptions

### DIFF
--- a/src/driver/controller-synology/index.js
+++ b/src/driver/controller-synology/index.js
@@ -128,7 +128,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       case "synology-iscsi":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 
@@ -141,7 +141,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       case "synology-iscsi":
         return "iscsi";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -71,7 +71,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
       case "zfs-generic-nvmeof":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -87,7 +87,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
       case "zfs-local-zvol":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -1975,7 +1975,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       case "truenas-api-iscsi":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 
@@ -1991,7 +1991,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       case "truenas-api-iscsi":
         return "iscsi";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -105,7 +105,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
       case "truenas-iscsi":
         return "volume";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 
@@ -161,7 +161,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
       case "truenas-iscsi":
         return "iscsi";
       default:
-        throw new Error("unknown driver: " + this.ctx.args.driver);
+        throw new Error("unknown driver: " + this.options.driver);
     }
   }
 


### PR DESCRIPTION
When working on https://github.com/democratic-csi/democratic-csi/pull/433 I found that some of the exceptions have `undefined` instead of driver name.

This is a simple fix for this issue.
I created a separate pull request to make review easier.