### PR TITLE
Add the ability to set ZFS snapshot properties (functionally identical to `datasetProperties`)

### DIFF
--- a/examples/freenas-api-iscsi.yaml
+++ b/examples/freenas-api-iscsi.yaml
@@ -33,6 +33,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   # total volume name (zvol/<datasetParentName>/<pvc name>) length cannot exceed 63 chars
   # https://www.ixsystems.com/documentation/freenas/11.2-U5/storage.html#zfs-zvol-config-opts-tab

--- a/examples/freenas-api-nfs.yaml
+++ b/examples/freenas-api-nfs.yaml
@@ -33,6 +33,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetParentName: tank/k8s/a/vols
   # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap

--- a/examples/freenas-api-smb.yaml
+++ b/examples/freenas-api-smb.yaml
@@ -33,6 +33,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   # these are managed automatically via the volume creation process when flagged as an smb volume
   #datasetProperties:

--- a/examples/freenas-iscsi.yaml
+++ b/examples/freenas-iscsi.yaml
@@ -43,6 +43,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   # total volume name (zvol/<datasetParentName>/<pvc name>) length cannot exceed 63 chars
   # https://www.ixsystems.com/documentation/freenas/11.2-U5/storage.html#zfs-zvol-config-opts-tab

--- a/examples/freenas-nfs.yaml
+++ b/examples/freenas-nfs.yaml
@@ -43,6 +43,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetParentName: tank/k8s/a/vols
   # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap

--- a/examples/freenas-smb.yaml
+++ b/examples/freenas-smb.yaml
@@ -43,6 +43,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetProperties:
     aclmode: restricted

--- a/examples/zfs-generic-iscsi.yaml
+++ b/examples/zfs-generic-iscsi.yaml
@@ -27,6 +27,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetParentName: tank/k8s/test
   # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap

--- a/examples/zfs-generic-nfs.yaml
+++ b/examples/zfs-generic-nfs.yaml
@@ -27,6 +27,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetParentName: tank/k8s/test
   # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap

--- a/examples/zfs-generic-nvmeof.yaml
+++ b/examples/zfs-generic-nvmeof.yaml
@@ -27,6 +27,8 @@ zfs:
   #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
   #  "org.freenas:test": "{{ parameters.foo }}"
   #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetParentName: tank/k8s/test
   # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap

--- a/examples/zfs-generic-smb.yaml
+++ b/examples/zfs-generic-smb.yaml
@@ -28,6 +28,8 @@ zfs:
     #aclinherit: passthrough
     #acltype: nfsv4
     casesensitivity: insensitive
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetParentName: tank/k8s/test
   # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap

--- a/examples/zfs-local-dataset.yaml
+++ b/examples/zfs-local-dataset.yaml
@@ -6,6 +6,8 @@ zfs:
 
   datasetProperties:
     # key: value
+  snapshotProperties:
+  #  "org.freenas:key": "value"
 
   datasetEnableQuotas: true
   datasetEnableReservation: false

--- a/examples/zfs-local-zvol.yaml
+++ b/examples/zfs-local-zvol.yaml
@@ -6,6 +6,8 @@ zfs:
 
   datasetProperties:
     # key: value
+  snapshotProperties:
+  #  "org.freenas:key": "value"
 
   zvolCompression:
   zvolDedup:

--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -2106,6 +2106,19 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       );
     }
 
+    // user-supplied properties
+    // put early to prevent stupid (user-supplied values overwriting system values)
+    if (driver.options.zfs.snapshotProperties) {
+      for (let property in driver.options.zfs.snapshotProperties) {
+        let value = driver.options.zfs.snapshotProperties[property];
+        const template = Handlebars.compile(value);
+
+        snapshotProperties[property] = template({
+          parameters: call.request.parameters,
+        });
+      }
+    }
+
     const volumeDatasetName = volumeParentDatasetName + "/" + source_volume_id;
     const datasetName = datasetParentName + "/" + source_volume_id;
     snapshotProperties[SNAPSHOT_CSI_NAME_PROPERTY_NAME] = name;

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -4000,6 +4000,19 @@ class FreeNASApiDriver extends CsiBaseDriver {
       );
     }
 
+    // user-supplied properties
+    // put early to prevent stupid (user-supplied values overwriting system values)
+    if (driver.options.zfs.snapshotProperties) {
+      for (let property in driver.options.zfs.snapshotProperties) {
+        let value = driver.options.zfs.snapshotProperties[property];
+        const template = Handlebars.compile(value);
+
+        snapshotProperties[property] = template({
+          parameters: call.request.parameters,
+        });
+      }
+    }
+
     const datasetName = datasetParentName + "/" + source_volume_id;
     snapshotProperties[SNAPSHOT_CSI_NAME_PROPERTY_NAME] = name;
     snapshotProperties[SNAPSHOT_CSI_SOURCE_VOLUME_ID_PROPERTY_NAME] =


### PR DESCRIPTION
This adds ZFS snapshot logic, identical to the logic for ZFS datasets, that allows users to set snapshot properties. This adds a new optional field `snapshotProperties` to the ZFS config options.