### PR TITLE
Add context fields to logs

### DIFF
--- a/bin/democratic-csi
+++ b/bin/democratic-csi
@@ -26,9 +26,8 @@ const args = require("yargs")
       // CONTAINER_SANDBOX_MOUNT_POINT  C:\C\0eac9a8da76f6d7119c5d9f86c8b3106d67dbbf01dbeb22fdc0192476b7e31cb\
       // path is injected as C:\config\driver-config-file.yaml
       if (process.env.CONTAINER_SANDBOX_MOUNT_POINT) {
-        path = `${
-          process.env.CONTAINER_SANDBOX_MOUNT_POINT
-        }${stripWindowsDriveLetter(path)}`;
+        path = `${process.env.CONTAINER_SANDBOX_MOUNT_POINT
+          }${stripWindowsDriveLetter(path)}`;
       }
 
       try {
@@ -118,6 +117,7 @@ const cache = new LRU({ max: 500 });
 const { logger } = require("../src/utils/logger");
 const { GrpcError } = require("../src/utils/grpc");
 const GeneralUtils = require("../src/utils/general");
+const uuidv4 = require("uuid").v4;
 
 if (args.logLevel) {
   logger.level = args.logLevel;
@@ -178,24 +178,32 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
     }
   }
 
+  const requestReadableID = GeneralUtils.loggerIdFromRequest(call, serviceMethodName);
+  const requestUUID = uuidv4();
+  const callContext = {
+    logger: logger.child({
+      method: serviceMethodName,
+      requestId: requestReadableID,
+      uuid: requestUUID,
+    }),
+  };
   try {
-    logger.info(
-      "new request - driver: %s method: %s call: %j",
+    callContext.logger.info(
+      "new request: driver=%s, call: %j",
       driver.constructor.name,
-      serviceMethodName,
       cleansedCall
     );
 
     const lockKeys = GeneralUtils.lockKeysFromRequest(call, serviceMethodName);
     if (lockKeys.length > 0) {
-      logger.debug("operation lock keys: %j", lockKeys);
+      callContext.logger.debug("operation lock keys: %j", lockKeys);
       // check locks
       lockKeys.forEach((key) => {
         if (operationLock.has(key)) {
           throw new GrpcError(
             grpc.status.ABORTED,
             "operation locked due to in progress operation(s): " +
-              JSON.stringify(lockKeys)
+            JSON.stringify(lockKeys)
           );
         }
       });
@@ -216,13 +224,13 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
     let response;
     let responseError;
     try {
-      // aquire locks
+      // acquire locks
       if (lockKeys.length > 0) {
         lockKeys.forEach((key) => {
           operationLock.add(key);
         });
       }
-      response = await driver[serviceMethodName](call);
+      response = await driver[serviceMethodName](call, callContext);
     } catch (e) {
       responseError = e;
     } finally {
@@ -246,10 +254,8 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
       );
     }
 
-    logger.info(
-      "new response - driver: %s method: %s response: %j",
-      driver.constructor.name,
-      serviceMethodName,
+    callContext.logger.info(
+      "new response: %j",
       response
     );
 
@@ -265,10 +271,8 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
       message = stringify(e);
     }
 
-    logger.error(
-      "handler error - driver: %s method: %s error: %s",
-      driver.constructor.name,
-      serviceMethodName,
+    callContext.logger.error(
+      "handler error: %s",
       message
     );
 
@@ -498,8 +502,7 @@ if (process.env.LOG_MEMORY_USAGE == "1") {
     const used = process.memoryUsage();
     for (let key in used) {
       console.log(
-        `[${new Date()}] Memory Usage: ${key} ${
-          Math.round((used[key] / 1024 / 1024) * 100) / 100
+        `[${new Date()}] Memory Usage: ${key} ${Math.round((used[key] / 1024 / 1024) * 100) / 100
         } MB`
       );
     }
@@ -513,7 +516,7 @@ if (process.env.MANUAL_GC == "1") {
       if (global.gc) {
         global.gc();
       }
-    } catch (e) {}
+    } catch (e) { }
   }, process.env.MANUAL_GC_INTERVAL || 60000);
 }
 
@@ -522,7 +525,7 @@ if (process.env.LOG_GRPC_SESSIONS == "1") {
     console.log("dumping sessions");
     try {
       console.log(csiServer.sessions);
-    } catch (e) {}
+    } catch (e) { }
   }, 5000);
 }
 

--- a/bin/democratic-csi
+++ b/bin/democratic-csi
@@ -26,8 +26,9 @@ const args = require("yargs")
       // CONTAINER_SANDBOX_MOUNT_POINT  C:\C\0eac9a8da76f6d7119c5d9f86c8b3106d67dbbf01dbeb22fdc0192476b7e31cb\
       // path is injected as C:\config\driver-config-file.yaml
       if (process.env.CONTAINER_SANDBOX_MOUNT_POINT) {
-        path = `${process.env.CONTAINER_SANDBOX_MOUNT_POINT
-          }${stripWindowsDriveLetter(path)}`;
+        path = `${
+          process.env.CONTAINER_SANDBOX_MOUNT_POINT
+        }${stripWindowsDriveLetter(path)}`;
       }
 
       try {
@@ -203,7 +204,7 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
           throw new GrpcError(
             grpc.status.ABORTED,
             "operation locked due to in progress operation(s): " +
-            JSON.stringify(lockKeys)
+              JSON.stringify(lockKeys)
           );
         }
       });
@@ -502,7 +503,8 @@ if (process.env.LOG_MEMORY_USAGE == "1") {
     const used = process.memoryUsage();
     for (let key in used) {
       console.log(
-        `[${new Date()}] Memory Usage: ${key} ${Math.round((used[key] / 1024 / 1024) * 100) / 100
+        `[${new Date()}] Memory Usage: ${key} ${
+          Math.round((used[key] / 1024 / 1024) * 100) / 100
         } MB`
       );
     }
@@ -516,7 +518,7 @@ if (process.env.MANUAL_GC == "1") {
       if (global.gc) {
         global.gc();
       }
-    } catch (e) { }
+    } catch (e) {}
   }, process.env.MANUAL_GC_INTERVAL || 60000);
 }
 
@@ -525,7 +527,7 @@ if (process.env.LOG_GRPC_SESSIONS == "1") {
     console.log("dumping sessions");
     try {
       console.log(csiServer.sessions);
-    } catch (e) { }
+    } catch (e) {}
   }, 5000);
 }
 

--- a/src/driver/controller-client-common/index.js
+++ b/src/driver/controller-client-common/index.js
@@ -156,9 +156,9 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(capabilities, callContext) {
     const driver = this;
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     let fs_types = driver.getFsTypes();
@@ -548,7 +548,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(call, callContext) {
     const driver = this;
 
     const config_key = driver.getConfigKey();
@@ -560,7 +560,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -661,7 +661,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
                   );
                 }
 
-                driver.ctx.logger.debug(
+                callContext.logger.debug(
                   "controller volume source path: %s",
                   source_path
                 );
@@ -740,7 +740,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
               );
           }
           break;
-        // must be available when adverstising CLONE_VOLUME
+        // must be available when advertising CLONE_VOLUME
         // create snapshot first, then clone
         case "volume":
           source_path = driver.getControllerVolumePath(
@@ -754,7 +754,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
             );
           }
 
-          driver.ctx.logger.debug(
+          callContext.logger.debug(
             "controller volume source path: %s",
             source_path
           );
@@ -770,7 +770,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
 
     // set mode
     if (this.options[config_key].dirPermissionsMode) {
-      driver.ctx.logger.verbose(
+      callContext.logger.verbose(
         "setting dir mode to: %s on dir: %s",
         this.options[config_key].dirPermissionsMode,
         volume_path
@@ -783,14 +783,14 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
       this.options[config_key].dirPermissionsUser ||
       this.options[config_key].dirPermissionsGroup
     ) {
-      driver.ctx.logger.verbose(
+      callContext.logger.verbose(
         "setting ownership to: %s:%s on dir: %s",
         this.options[config_key].dirPermissionsUser,
         this.options[config_key].dirPermissionsGroup,
         volume_path
       );
       if (this.getNodeIsWindows()) {
-        driver.ctx.logger.warn("chown not implemented on windows");
+        callContext.logger.warn("chown not implemented on windows");
       } else {
         await driver.exec("chown", [
           (this.options[config_key].dirPermissionsUser
@@ -840,7 +840,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(call, callContext) {
     const driver = this;
 
     const volume_id = call.request.volume_id;
@@ -873,7 +873,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -885,7 +885,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     const driver = this;
 
     if (
@@ -902,7 +902,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -925,7 +925,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -936,7 +936,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -963,7 +963,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(call, callContext) {
     const driver = this;
 
     const config_key = driver.getConfigKey();
@@ -1003,7 +1003,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
       );
     }
 
-    driver.ctx.logger.verbose("requested snapshot name: %s", name);
+    callContext.logger.verbose("requested snapshot name: %s", name);
 
     let invalid_chars;
     invalid_chars = name.match(/[^a-z0-9_\-:.+]+/gi);
@@ -1020,7 +1020,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
     // https://stackoverflow.com/questions/32106243/regex-to-remove-all-non-alpha-numeric-and-replace-spaces-with/32106277
     name = name.replace(/[^a-z0-9_\-:.+]+/gi, "");
 
-    driver.ctx.logger.verbose("cleansed snapshot name: %s", name);
+    callContext.logger.verbose("cleansed snapshot name: %s", name);
     const volume_path = driver.getControllerVolumePath(source_volume_id);
     //const volume_path = "/home/thansen/beets/";
     //const volume_path = "/var/lib/docker/";
@@ -1044,11 +1044,11 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
             await driver.cloneDir(volume_path, snapshot_path).finally(() => {
               SNAPSHOTS_CUT_IN_FLIGHT.delete(name);
             });
-            driver.ctx.logger.info(
+            callContext.logger.info(
               `filecopy backup finished: snapshot_id=${snapshot_id}, path=${volume_path}`
             );
           } else {
-            driver.ctx.logger.debug(
+            callContext.logger.debug(
               `filecopy backup already cut: ${snapshot_id}`
             );
           }
@@ -1099,7 +1099,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
           if (response.length > 0) {
             snapshot_exists = true;
             const snapshot = response[response.length - 1];
-            driver.ctx.logger.debug(
+            callContext.logger.debug(
               `restic backup already cut: ${snapshot.id}`
             );
             const stats = await restic.stats([snapshot.id]);
@@ -1136,7 +1136,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
               return message.message_type == "summary";
             });
             snapshot_id = summary.snapshot_id;
-            driver.ctx.logger.info(
+            callContext.logger.info(
               `restic backup finished: snapshot_id=${snapshot_id}, path=${volume_path}, total_duration=${
                 summary.total_duration | 0
               }s`
@@ -1194,7 +1194,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
               );
             }
             snapshot_id = snapshot.id;
-            driver.ctx.logger.info(
+            callContext.logger.info(
               `restic backup successfully applied additional tags: new_snapshot_id=${snapshot_id}, original_snapshot_id=${original_snapshot_id} path=${volume_path}`
             );
           }
@@ -1233,7 +1233,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
           if (response.length > 0) {
             snapshot_exists = true;
             const snapshot = response[response.length - 1];
-            driver.ctx.logger.debug(
+            callContext.logger.debug(
               `kopia snapshot already cut: ${snapshot.id}`
             );
 
@@ -1262,7 +1262,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
               1000;
             size_bytes = response.rootEntry.summ.size;
 
-            driver.ctx.logger.info(
+            callContext.logger.info(
               `kopia backup finished: snapshot_id=${snapshot_id}, path=${volume_path}, total_duration=${
                 total_duration | 0
               }s`
@@ -1305,7 +1305,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(call, callContext) {
     const driver = this;
 
     let snapshot_id = call.request.snapshot_id;
@@ -1393,7 +1393,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     const driver = this;
 
     const volume_id = call.request.volume_id;
@@ -1414,7 +1414,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
       );
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/controller-local-hostpath/index.js
+++ b/src/driver/controller-local-hostpath/index.js
@@ -78,7 +78,7 @@ class ControllerLocalHostpathDriver extends ControllerClientCommonDriver {
    * @param {*} call
    * @returns
    */
-  async NodeGetInfo(call) {
+  async NodeGetInfo(call, callContext) {
     const response = await super.NodeGetInfo(...arguments);
     response.accessible_topology = {
       segments: {

--- a/src/driver/controller-objectivefs/index.js
+++ b/src/driver/controller-objectivefs/index.js
@@ -159,9 +159,9 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
     return ["fuse.objectivefs", "objectivefs"];
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(capabilities, callContext) {
     const driver = this;
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     let fs_types = driver.getFsTypes();
@@ -347,7 +347,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -651,7 +651,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
       throw new GrpcError(grpc.status.INVALID_ARGUMENT, `missing capabilities`);
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/controller-objectivefs/index.js
+++ b/src/driver/controller-objectivefs/index.js
@@ -270,7 +270,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(call, callContext) {
     const driver = this;
     const pool = _.get(driver.options, "objectivefs.pool");
     const object_store = _.get(driver.options, "objectivefs.env.OBJECTSTORE");
@@ -301,7 +301,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(call, callContext) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");
@@ -446,7 +446,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(call, callContext) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");
@@ -481,7 +481,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -493,7 +493,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -506,7 +506,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(call, callContext) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");
@@ -588,7 +588,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -599,7 +599,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -612,7 +612,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -623,7 +623,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");

--- a/src/driver/controller-synology/index.js
+++ b/src/driver/controller-synology/index.js
@@ -250,9 +250,9 @@ class ControllerSynologyDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(capabilities, callContext) {
     const driverResourceType = this.getDriverResourceType();
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     //[{"access_mode":{"mode":"SINGLE_NODE_WRITER"},"mount":{"mount_flags":["noatime","_netdev"],"fs_type":"nfs"},"access_type":"mount"}]
@@ -319,7 +319,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(call, callContext) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -330,7 +330,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -677,7 +677,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(call, callContext) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -785,7 +785,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(call, callContext) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -877,7 +877,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
     const location = driver.getLocation();
@@ -890,7 +890,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -907,7 +907,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -918,7 +918,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -929,7 +929,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(call, callContext) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -951,7 +951,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       );
     }
 
-    driver.ctx.logger.verbose("requested snapshot name: %s", name);
+    callContext.logger.verbose("requested snapshot name: %s", name);
 
     let invalid_chars;
     invalid_chars = name.match(/[^a-z0-9_\-:.+]+/gi);
@@ -1049,7 +1049,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(call, callContext) {
     // throw new GrpcError(
     //   grpc.status.UNIMPLEMENTED,
     //   `operation not supported by driver`
@@ -1100,7 +1100,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -1150,7 +1150,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
         break;
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
     if (result.valid !== true) {
       return { message: result.message };
     }

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -98,7 +98,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} datasetName
    */
-  async createShare(call, datasetName, callContext) {
+  async createShare(callContext, call, datasetName) {
     const driver = this;
     const zb = await this.getZetabyte();
     const execClient = this.getExecClient();
@@ -118,7 +118,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
                   key
                 ]
               ) {
-                await zb.zfs.set(datasetName, {
+                await zb.zfs.set(callContext, datasetName, {
                   [key]:
                     this.options.nfs.shareStrategySetDatasetProperties
                       .properties[key],
@@ -131,7 +131,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
             break;
         }
 
-        properties = await zb.zfs.get(datasetName, ["mountpoint"]);
+        properties = await zb.zfs.get(callContext, datasetName, ["mountpoint"]);
         properties = properties[datasetName];
         callContext.logger.debug("zfs props data: %j", properties);
 
@@ -152,7 +152,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
                   key
                 ]
               ) {
-                await zb.zfs.set(datasetName, {
+                await zb.zfs.set(callContext, datasetName, {
                   [key]:
                     this.options.smb.shareStrategySetDatasetProperties
                       .properties[key],
@@ -166,7 +166,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
             break;
         }
 
-        properties = await zb.zfs.get(datasetName, ["mountpoint"]);
+        properties = await zb.zfs.get(callContext, datasetName, ["mountpoint"]);
         properties = properties[datasetName];
         callContext.logger.debug("zfs props data: %j", properties);
 
@@ -306,7 +306,7 @@ create /backstores/block/${assetName}
         callContext.logger.info("iqn: " + iqn);
 
         // store this off to make delete process more bullet proof
-        await zb.zfs.set(datasetName, {
+        await zb.zfs.set(callContext, datasetName, {
           [ISCSI_ASSETS_NAME_PROPERTY_NAME]: assetName,
         });
 
@@ -531,7 +531,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
         callContext.logger.info("nqn: " + nqn);
 
         // store this off to make delete process more bullet proof
-        await zb.zfs.set(datasetName, {
+        await zb.zfs.set(callContext, datasetName, {
           [NVMEOF_ASSETS_NAME_PROPERTY_NAME]: assetName,
         });
 
@@ -555,7 +555,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
     }
   }
 
-  async deleteShare(call, datasetName, callContext) {
+  async deleteShare(callContext, call, datasetName) {
     const zb = await this.getZetabyte();
     const execClient = this.getExecClient();
 
@@ -573,7 +573,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
                 ]
               ) {
                 try {
-                  await zb.zfs.inherit(datasetName, key);
+                  await zb.zfs.inherit(callContext, datasetName, key);
                 } catch (err) {
                   if (err.toString().includes("dataset does not exist")) {
                     // do nothing
@@ -603,7 +603,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
                 ]
               ) {
                 try {
-                  await zb.zfs.inherit(datasetName, key);
+                  await zb.zfs.inherit(callContext, datasetName, key);
                 } catch (err) {
                   if (err.toString().includes("dataset does not exist")) {
                     // do nothing
@@ -629,7 +629,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
 
         // Delete iscsi assets
         try {
-          properties = await zb.zfs.get(datasetName, [
+          properties = await zb.zfs.get(callContext, datasetName, [
             ISCSI_ASSETS_NAME_PROPERTY_NAME,
           ]);
         } catch (err) {
@@ -701,7 +701,7 @@ delete ${assetName}
 
         // Delete nvmeof assets
         try {
-          properties = await zb.zfs.get(datasetName, [
+          properties = await zb.zfs.get(callContext, datasetName, [
             NVMEOF_ASSETS_NAME_PROPERTY_NAME,
           ]);
         } catch (err) {
@@ -830,7 +830,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
     return {};
   }
 
-  async expandVolume(call, datasetName, callContext) {
+  async expandVolume(callContext, call, datasetName) {
     switch (this.options.driver) {
       case "zfs-generic-nfs":
         break;

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -74,10 +74,10 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
     }
   }
 
-  generateSmbShareName(datasetName) {
+  generateSmbShareName(callContext, datasetName) {
     const driver = this;
 
-    driver.ctx.logger.verbose(
+    callContext.logger.verbose(
       `generating smb share name for dataset: ${datasetName}`
     );
 
@@ -85,7 +85,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
     name = name.replaceAll("/", "_");
     name = name.replaceAll("-", "_");
 
-    driver.ctx.logger.verbose(
+    callContext.logger.verbose(
       `generated smb share name for dataset (${datasetName}): ${name}`
     );
 
@@ -98,7 +98,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} datasetName
    */
-  async createShare(call, datasetName) {
+  async createShare(call, datasetName, callContext) {
     const driver = this;
     const zb = await this.getZetabyte();
     const execClient = this.getExecClient();
@@ -133,7 +133,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
 
         properties = await zb.zfs.get(datasetName, ["mountpoint"]);
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         volume_context = {
           node_attach_driver: "nfs",
@@ -160,7 +160,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
               }
             }
 
-            share = driver.generateSmbShareName(datasetName);
+            share = driver.generateSmbShareName(callContext, datasetName);
             break;
           default:
             break;
@@ -168,7 +168,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
 
         properties = await zb.zfs.get(datasetName, ["mountpoint"]);
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         volume_context = {
           node_attach_driver: "smb",
@@ -264,7 +264,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
               3,
               2000,
               async () => {
-                await this.targetCliCommand(
+                await this.targetCliCommand(callContext,
                   `
 # create target
 cd /iscsi
@@ -303,7 +303,7 @@ create /backstores/block/${assetName}
 
         // iqn = target
         let iqn = basename + ":" + assetName;
-        this.ctx.logger.info("iqn: " + iqn);
+        callContext.logger.info("iqn: " + iqn);
 
         // store this off to make delete process more bullet proof
         await zb.zfs.set(datasetName, {
@@ -403,7 +403,7 @@ create ${basename}:${assetName}
                 3,
                 2000,
                 async () => {
-                  await this.nvmetCliCommand(
+                  await this.nvmetCliCommand(callContext,
                     `
 # create subsystem
 cd /subsystems
@@ -487,7 +487,7 @@ create ${listenerAttributesText}
                 3,
                 2000,
                 async () => {
-                  await this.spdkCliCommand(
+                  await this.spdkCliCommand(callContext,
                     `
 # create bdev
 cd /bdevs/${this.options.nvmeof.shareStrategySpdkCli.bdev.type}
@@ -528,7 +528,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
 
         // iqn = target
         let nqn = basename + ":" + assetName;
-        this.ctx.logger.info("nqn: " + nqn);
+        callContext.logger.info("nqn: " + nqn);
 
         // store this off to make delete process more bullet proof
         await zb.zfs.set(datasetName, {
@@ -555,7 +555,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
     }
   }
 
-  async deleteShare(call, datasetName) {
+  async deleteShare(call, datasetName, callContext) {
     const zb = await this.getZetabyte();
     const execClient = this.getExecClient();
 
@@ -640,7 +640,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
         }
 
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         assetName = properties[ISCSI_ASSETS_NAME_PROPERTY_NAME].value;
 
@@ -666,7 +666,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
               3,
               2000,
               async () => {
-                await this.targetCliCommand(
+                await this.targetCliCommand(callContext,
                   `
 # delete target
 cd /iscsi
@@ -712,7 +712,7 @@ delete ${assetName}
         }
 
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         assetName = properties[NVMEOF_ASSETS_NAME_PROPERTY_NAME].value;
 
@@ -756,7 +756,7 @@ delete ${basename}:${assetName}
                 3,
                 2000,
                 async () => {
-                  await this.nvmetCliCommand(
+                  await this.nvmetCliCommand(callContext,
                     `
 # delete subsystem from port
 ${portCommands}
@@ -787,7 +787,7 @@ saveconfig ${savefile}
                 3,
                 2000,
                 async () => {
-                  await this.spdkCliCommand(
+                  await this.spdkCliCommand(callContext,
                     `
 # delete subsystem
 cd /nvmf/subsystem/
@@ -830,7 +830,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
     return {};
   }
 
-  async expandVolume(call, datasetName) {
+  async expandVolume(call, datasetName, callContext) {
     switch (this.options.driver) {
       case "zfs-generic-nfs":
         break;
@@ -850,7 +850,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
     }
   }
 
-  async targetCliCommand(data) {
+  async targetCliCommand(callContext, data) {
     const execClient = this.getExecClient();
     const driver = this;
 
@@ -887,7 +887,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       logCommand += "\n";
     });
 
-    driver.ctx.logger.verbose("TargetCLI command: " + logCommand);
+    callContext.logger.verbose("TargetCLI command: " + logCommand);
 
     // https://github.com/democratic-csi/democratic-csi/issues/127
     // https://bugs.launchpad.net/ubuntu/+source/python-configshell-fb/+bug/1776761
@@ -901,7 +901,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       execClient.buildCommand(command, args),
       options
     );
-    driver.ctx.logger.verbose(
+    callContext.logger.verbose(
       "TargetCLI response: " + JSON.stringify(response)
     );
     if (response.code != 0) {
@@ -910,7 +910,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
     return response;
   }
 
-  async nvmetCliCommand(data) {
+  async nvmetCliCommand(callContext, data) {
     const execClient = this.getExecClient();
     const driver = this;
 
@@ -974,7 +974,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       logCommand += "\n";
     });
 
-    driver.ctx.logger.verbose("nvmetCLI command: " + logCommand);
+    callContext.logger.verbose("nvmetCLI command: " + logCommand);
     //process.exit(0);
 
     // https://github.com/democratic-csi/democratic-csi/issues/127
@@ -989,14 +989,14 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       execClient.buildCommand(command, args),
       options
     );
-    driver.ctx.logger.verbose("nvmetCLI response: " + JSON.stringify(response));
+    callContext.logger.verbose("nvmetCLI response: " + JSON.stringify(response));
     if (response.code != 0) {
       throw response;
     }
     return response;
   }
 
-  async spdkCliCommand(data) {
+  async spdkCliCommand(callContext, data) {
     const execClient = this.getExecClient();
     const driver = this;
 
@@ -1033,7 +1033,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       logCommand += "\n";
     });
 
-    driver.ctx.logger.verbose("spdkCLI command: " + logCommand);
+    callContext.logger.verbose("spdkCLI command: " + logCommand);
     //process.exit(0);
 
     // https://github.com/democratic-csi/democratic-csi/issues/127
@@ -1048,7 +1048,7 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       execClient.buildCommand(command, args),
       options
     );
-    driver.ctx.logger.verbose("spdkCLI response: " + JSON.stringify(response));
+    callContext.logger.verbose("spdkCLI response: " + JSON.stringify(response));
     if (response.code != 0) {
       throw response;
     }

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -160,7 +160,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} datasetName
    */
-  async createShare(call, datasetName) {
+  async createShare(call, datasetName, callContext) {
     let volume_context = {};
 
     switch (this.options.driver) {
@@ -193,7 +193,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    * @param {*} datasetName
    * @returns
    */
-  async deleteShare(call, datasetName) {
+  async deleteShare(call, datasetName, callContext) {
     return {};
   }
 
@@ -203,7 +203,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    * @param {*} call
    * @param {*} datasetName
    */
-  async expandVolume(call, datasetName) {}
+  async expandVolume(call, datasetName, callContext) {}
 
   /**
    * List of topologies associated with the *volume*

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -227,7 +227,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    * @param {*} call
    * @returns
    */
-  async NodeGetInfo(call) {
+  async NodeGetInfo(call, callContext) {
     const response = await super.NodeGetInfo(...arguments);
     response.accessible_topology = {
       segments: {

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -160,7 +160,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} datasetName
    */
-  async createShare(call, datasetName, callContext) {
+  async createShare(callContext, call, datasetName) {
     let volume_context = {};
 
     switch (this.options.driver) {
@@ -193,7 +193,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    * @param {*} datasetName
    * @returns
    */
-  async deleteShare(call, datasetName, callContext) {
+  async deleteShare(callContext, call, datasetName) {
     return {};
   }
 
@@ -203,7 +203,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    * @param {*} call
    * @param {*} datasetName
    */
-  async expandVolume(call, datasetName, callContext) {}
+  async expandVolume(callContext, call, datasetName) {}
 
   /**
    * List of topologies associated with the *volume*

--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -41,9 +41,9 @@ const MAX_ZVOL_NAME_LENGTH_CACHE_KEY = "controller-zfs:max_zvol_name_length";
  *  - getFSTypes() // optional
  *  - getAccessModes(capability) // optional
  *  - async getAccessibleTopology() // optional
- *  - async createShare(call, datasetName) // return appropriate volume_context for Node operations
- *  - async deleteShare(call, datasetName) // no return expected
- *  - async expandVolume(call, datasetName) // no return expected, used for restarting services etc if needed
+ *  - async createShare(call, datasetName, callContext) // return appropriate volume_context for Node operations
+ *  - async deleteShare(call, datasetName, callContext) // no return expected
+ *  - async expandVolume(call, datasetName, callContext) // no return expected, used for restarting services etc if needed
  */
 class ControllerZfsBaseDriver extends CsiBaseDriver {
   constructor(ctx, options) {
@@ -152,11 +152,11 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     }
   }
 
-  async getWhoAmI() {
+  async getWhoAmI(callContext) {
     const driver = this;
     const execClient = driver.getExecClient();
     const command = "whoami";
-    driver.ctx.logger.verbose("whoami command: %s", command);
+    callContext.logger.verbose("whoami command: %s", command);
     const response = await execClient.exec(command);
     if (response.code !== 0) {
       throw new Error("failed to run uname to determine max zvol name length");
@@ -250,9 +250,9 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(capabilities, callContext) {
     const driverZfsResourceType = this.getDriverZfsResourceType();
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     //[{"access_mode":{"mode":"SINGLE_NODE_WRITER"},"mount":{"mount_flags":["noatime","_netdev"],"fs_type":"nfs"},"access_type":"mount"}]
@@ -346,7 +346,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     return volume_status;
   }
 
-  async populateCsiVolumeFromData(row) {
+  async populateCsiVolumeFromData(callContext, row) {
     const driver = this;
     const zb = await this.getZetabyte();
     const driverZfsResourceType = this.getDriverZfsResourceType();
@@ -360,7 +360,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     if (
       !zb.helpers.isPropertyValueSet(row[SHARE_VOLUME_CONTEXT_PROPERTY_NAME])
     ) {
-      driver.ctx.logger.warn(`${row.name} is missing share context`);
+      callContext.logger.warn(`${row.name} is missing share context`);
       return;
     }
 
@@ -430,7 +430,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    * https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=238112
    * https://svnweb.freebsd.org/base?view=revision&revision=343485
    */
-  async getMaxZvolNameLength() {
+  async getMaxZvolNameLength(callContext) {
     const driver = this;
     const execClient = driver.getExecClient();
 
@@ -449,7 +449,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
 
     // get kernel
     command = "uname -s";
-    driver.ctx.logger.verbose("uname command: %s", command);
+    callContext.logger.verbose("uname command: %s", command);
     response = await execClient.exec(command);
     if (response.code !== 0) {
       throw new Error("failed to run uname to determine max zvol name length");
@@ -468,7 +468,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       case "freebsd":
         // get kernel_release
         command = "uname -r";
-        driver.ctx.logger.verbose("uname command: %s", command);
+        callContext.logger.verbose("uname command: %s", command);
         response = await execClient.exec(command);
         if (response.code !== 0) {
           throw new Error(
@@ -496,16 +496,16 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     return max;
   }
 
-  async setFilesystemMode(path, mode) {
+  async setFilesystemMode(callContext, path, mode) {
     const driver = this;
     const execClient = this.getExecClient();
 
     let command = execClient.buildCommand("chmod", [mode, path]);
-    if ((await driver.getWhoAmI()) != "root") {
+    if ((await driver.getWhoAmI(callContext)) != "root") {
       command = (await driver.getSudoPath()) + " " + command;
     }
 
-    driver.ctx.logger.verbose("set permission command: %s", command);
+    callContext.logger.verbose("set permission command: %s", command);
 
     let response = await execClient.exec(command);
     if (response.code != 0) {
@@ -516,7 +516,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     }
   }
 
-  async setFilesystemOwnership(path, user = false, group = false) {
+  async setFilesystemOwnership(callContext, path, user = false, group = false) {
     const driver = this;
     const execClient = this.getExecClient();
 
@@ -539,11 +539,11 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       (user.length > 0 ? user : "") + ":" + (group.length > 0 ? group : ""),
       path,
     ]);
-    if ((await driver.getWhoAmI()) != "root") {
+    if ((await driver.getWhoAmI(callContext)) != "root") {
       command = (await driver.getSudoPath()) + " " + command;
     }
 
-    driver.ctx.logger.verbose("set ownership command: %s", command);
+    callContext.logger.verbose("set ownership command: %s", command);
 
     let response = await execClient.exec(command);
     if (response.code != 0) {
@@ -562,7 +562,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(call, callContext) {
     const driver = this;
 
     if (driver.ctx.args.csiMode.includes("controller")) {
@@ -590,7 +590,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
        */
       if (!driver.currentExecShell || timerEnabled === false) {
         const execClient = this.getExecClient();
-        driver.ctx.logger.debug("performing exec sanity check..");
+        callContext.logger.debug("performing exec sanity check..");
         const response = await execClient.exec("echo $0");
         driver.currentExecShell = response.stdout.split("\n")[0];
       }
@@ -600,7 +600,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
         const intervalTime = 60000;
         driver.currentExecShellInterval = setInterval(async () => {
           try {
-            driver.ctx.logger.debug("performing exec sanity check..");
+            callContext.logger.debug("performing exec sanity check..");
             const execClient = this.getExecClient();
             const response = await execClient.exec("echo $0");
             driver.currentExecShell = response.stdout.split("\n")[0];
@@ -634,7 +634,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const execClient = this.getExecClient();
@@ -644,7 +644,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     let snapshotParentDatasetName = this.getDetachedSnapshotParentDatasetName();
     let zvolBlocksize = this.options.zfs.zvolBlocksize || "16K";
     let name = call.request.name;
-    let volume_id = await driver.getVolumeIdFromCall(call);
+    let volume_id = await driver.getVolumeIdFromCall(call, callContext);
     let volume_content_source = call.request.volume_content_source;
 
     if (!datasetParentName) {
@@ -658,7 +658,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -792,8 +792,8 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
      */
     if (driverZfsResourceType == "volume") {
       let extentDiskName = "zvol/" + datasetName;
-      let maxZvolNameLength = await driver.getMaxZvolNameLength();
-      driver.ctx.logger.debug("max zvol name length: %s", maxZvolNameLength);
+      let maxZvolNameLength = await driver.getMaxZvolNameLength(callContext);
+      callContext.logger.debug("max zvol name length: %s", maxZvolNameLength);
 
       if (extentDiskName.length > maxZvolNameLength) {
         throw new GrpcError(
@@ -849,7 +849,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       volumeProperties[VOLUME_CONTENT_SOURCE_TYPE_PROPERTY_NAME] =
         volume_content_source.type;
       switch (volume_content_source.type) {
-        // must be available when adverstising CREATE_DELETE_SNAPSHOT
+        // must be available when advertising CREATE_DELETE_SNAPSHOT
         // simply clone
         case "snapshot":
           try {
@@ -883,7 +883,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
               volume_id;
           }
 
-          driver.ctx.logger.debug("full snapshot name: %s", fullSnapshotName);
+          callContext.logger.debug("full snapshot name: %s", fullSnapshotName);
 
           if (!zb.helpers.isZfsSnapshot(volume_content_source_snapshot_id)) {
             try {
@@ -997,7 +997,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
             VOLUME_SOURCE_CLONE_SNAPSHOT_PREFIX +
             volume_id;
 
-          driver.ctx.logger.debug("full snapshot name: %s", fullSnapshotName);
+          callContext.logger.debug("full snapshot name: %s", fullSnapshotName);
 
           // create snapshot
           try {
@@ -1130,11 +1130,12 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
           VOLUME_CONTENT_SOURCE_ID_PROPERTY_NAME,
         ]);
         properties = properties[datasetName];
-        driver.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         // set mode
         if (this.options.zfs.datasetPermissionsMode) {
           await driver.setFilesystemMode(
+            callContext,
             properties.mountpoint.value,
             this.options.zfs.datasetPermissionsMode
           );
@@ -1148,6 +1149,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
             .length > 0
         ) {
           await driver.setFilesystemOwnership(
+            callContext,
             properties.mountpoint.value,
             this.options.zfs.datasetPermissionsUser,
             this.options.zfs.datasetPermissionsGroup
@@ -1155,7 +1157,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
         }
 
         // set acls
-        // TODO: this is unsfafe approach, make it better
+        // TODO: this is unsafe approach, make it better
         // probably could see if ^-.*\s and split and then shell escape
         if (this.options.zfs.datasetPermissionsAcls) {
           let aclBinary = _.get(
@@ -1168,11 +1170,11 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
               acl,
               properties.mountpoint.value,
             ]);
-            if ((await this.getWhoAmI()) != "root") {
+            if ((await driver.getWhoAmI(callContext)) != "root") {
               command = (await this.getSudoPath()) + " " + command;
             }
 
-            driver.ctx.logger.verbose("set acl command: %s", command);
+            callContext.logger.verbose("set acl command: %s", command);
             response = await execClient.exec(command);
             if (response.code != 0) {
               throw new GrpcError(
@@ -1222,7 +1224,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
         break;
     }
 
-    volume_context = await this.createShare(call, datasetName);
+    volume_context = await this.createShare(call, datasetName, callContext);
     await zb.zfs.set(datasetName, {
       [SHARE_VOLUME_CONTEXT_PROPERTY_NAME]: JSON.stringify(volume_context),
     });
@@ -1269,7 +1271,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(call, callContext) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -1314,7 +1316,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       }
     }
 
-    driver.ctx.logger.debug("dataset properties: %j", properties);
+    callContext.logger.debug("dataset properties: %j", properties);
 
     // deleteStrategy
     const delete_strategy = _.get(
@@ -1328,7 +1330,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     }
 
     // remove share resources
-    await this.deleteShare(call, datasetName);
+    await this.deleteShare(call, datasetName, callContext);
 
     // remove parent snapshot if appropriate with defer
     if (
@@ -1339,7 +1341,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
         .extractSnapshotName(properties.origin.value)
         .startsWith(VOLUME_SOURCE_CLONE_SNAPSHOT_PREFIX)
     ) {
-      driver.ctx.logger.debug(
+      callContext.logger.debug(
         "removing with defer source snapshot: %s",
         properties.origin.value
       );
@@ -1401,7 +1403,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -1503,7 +1505,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       await zb.zfs.set(datasetName, properties);
     }
 
-    await this.expandVolume(call, datasetName);
+    await this.expandVolume(call, datasetName, callContext);
 
     return {
       capacity_bytes:
@@ -1520,7 +1522,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -1534,7 +1536,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -1569,7 +1571,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerGetVolume(call) {
+  async ControllerGetVolume(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -1632,8 +1634,8 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       throw err;
     }
 
-    driver.ctx.logger.debug("list volumes result: %j", response);
-    let volume = await driver.populateCsiVolumeFromData(response.indexed[0]);
+    callContext.logger.debug("list volumes result: %j", response);
+    let volume = await driver.populateCsiVolumeFromData(callContext, response.indexed[0]);
     let status = await driver.getVolumeStatus(datasetName);
 
     let res = { volume };
@@ -1650,7 +1652,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -1747,7 +1749,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       throw err;
     }
 
-    driver.ctx.logger.debug("list volumes result: %j", response);
+    callContext.logger.debug("list volumes result: %j", response);
 
     // remove parent dataset from results
     if (driverZfsResourceType == "filesystem") {
@@ -1761,7 +1763,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
         continue;
       }
 
-      let volume = await driver.populateCsiVolumeFromData(row);
+      let volume = await driver.populateCsiVolumeFromData(callContext, row);
       if (volume) {
         let status = await driver.getVolumeStatus(datasetName);
         entries.push({
@@ -1790,7 +1792,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -2044,7 +2046,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -2113,7 +2115,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       source_volume_id;
     snapshotProperties[MANAGED_PROPERTY_NAME] = "true";
 
-    driver.ctx.logger.verbose("requested snapshot name: %s", name);
+    callContext.logger.verbose("requested snapshot name: %s", name);
 
     let invalid_chars;
     invalid_chars = name.match(/[^a-z0-9_\-:.+]+/gi);
@@ -2130,7 +2132,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     // https://stackoverflow.com/questions/32106243/regex-to-remove-all-non-alpha-numeric-and-replace-spaces-with/32106277
     name = name.replace(/[^a-z0-9_\-:.+]+/gi, "");
 
-    driver.ctx.logger.verbose("cleansed snapshot name: %s", name);
+    callContext.logger.verbose("cleansed snapshot name: %s", name);
 
     // check for other snapshopts with the same name on other volumes and fail as appropriate
     {
@@ -2189,7 +2191,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       fullSnapshotName = datasetName + "@" + name;
     }
 
-    driver.ctx.logger.verbose("full snapshot name: %s", fullSnapshotName);
+    callContext.logger.verbose("full snapshot name: %s", fullSnapshotName);
 
     if (detachedSnapshot) {
       tmpSnapshotName =
@@ -2297,7 +2299,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       { types }
     );
     properties = properties[fullSnapshotName];
-    driver.ctx.logger.verbose("snapshot properties: %j", properties);
+    callContext.logger.verbose("snapshot properties: %j", properties);
 
     // TODO: properly handle use-case where datasetEnableQuotas is not turned on
     if (driverZfsResourceType == "filesystem") {
@@ -2352,7 +2354,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(call, callContext) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -2383,7 +2385,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
 
     const fullSnapshotName = datasetParentName + "/" + snapshot_id;
 
-    driver.ctx.logger.verbose("deleting snapshot: %s", fullSnapshotName);
+    callContext.logger.verbose("deleting snapshot: %s", fullSnapshotName);
 
     try {
       await zb.zfs.destroy(fullSnapshotName, {
@@ -2423,7 +2425,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -2461,7 +2463,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       }
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -1796,7 +1796,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
   }
 
-  async removeSnapshotsFromDatatset(datasetName) {
+  async removeSnapshotsFromDataset(datasetName) {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     let job_id = await httpApiClient.DatasetDestroySnapshots(datasetName);
     await httpApiClient.CoreWaitForJob(job_id, 30);
@@ -2581,7 +2581,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
             }
 
             // remove snapshots from target
-            await this.removeSnapshotsFromDatatset(datasetName);
+            await this.removeSnapshotsFromDataset(datasetName);
           } else {
             try {
               response = await httpApiClient.CloneCreate(
@@ -2741,7 +2741,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
             );
 
             // remove snapshots from target
-            await this.removeSnapshotsFromDatatset(datasetName);
+            await this.removeSnapshotsFromDataset(datasetName);
 
             // remove snapshot from source
             await httpApiClient.SnapshotDelete(fullSnapshotName, {
@@ -4397,7 +4397,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       let containerDataset =
         zb.helpers.extractParentDatasetName(fullSnapshotName);
       try {
-        await this.removeSnapshotsFromDatatset(containerDataset);
+        await this.removeSnapshotsFromDataset(containerDataset);
         await httpApiClient.DatasetDelete(containerDataset);
       } catch (err) {
         if (!err.toString().includes("filesystem has children")) {

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -207,7 +207,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           "mountpoint",
           FREENAS_NFS_SHARE_PROPERTY_NAME,
         ]);
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         // create nfs share
         if (
@@ -419,7 +419,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           "mountpoint",
           FREENAS_SMB_SHARE_PROPERTY_NAME,
         ]);
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         let smbName;
 
@@ -442,7 +442,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
         smbName = smbName.toLowerCase();
 
-        this.ctx.logger.info(
+        callContext.logger.info(
           "FreeNAS creating smb share with name: " + smbName
         );
 
@@ -668,7 +668,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME,
           FREENAS_ISCSI_TARGETTOEXTENT_ID_PROPERTY_NAME,
         ]);
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         let basename;
         let iscsiName;
@@ -698,7 +698,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
         let extentDiskName = "zvol/" + datasetName;
         let maxZvolNameLength = await driver.getMaxZvolNameLength();
-        driver.ctx.logger.debug("max zvol name length: %s", maxZvolNameLength);
+        callContext.logger.debug("max zvol name length: %s", maxZvolNameLength);
 
         /**
          * limit is a FreeBSD limitation
@@ -719,7 +719,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           );
         }
 
-        this.ctx.logger.info(
+        callContext.logger.info(
           "FreeNAS creating iscsi assets with name: " + iscsiName
         );
 
@@ -793,7 +793,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
               );
             }
             basename = response.body.iscsi_basename;
-            this.ctx.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
+            callContext.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
             break;
           case 2:
             response = await httpClient.get("/iscsi/global");
@@ -806,7 +806,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
               );
             }
             basename = response.body.basename;
-            this.ctx.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
+            callContext.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
             break;
           default:
             throw new GrpcError(
@@ -876,7 +876,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                 );
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
+              callContext.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
               await zb.zfs.set(callContext, datasetName, {
@@ -958,7 +958,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                   );
                 }
 
-                this.ctx.logger.verbose(
+                callContext.logger.verbose(
                   "FreeNAS ISCSI TARGET_GROUP: %j",
                   targetGroup
                 );
@@ -1024,7 +1024,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                 );
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
+              callContext.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
 
               await httpApiClient.DatasetSet(datasetName, {
                 [FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME]: extent.id,
@@ -1082,7 +1082,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                   `unknown error creating iscsi targettoextent`
                 );
               }
-              this.ctx.logger.verbose(
+              callContext.logger.verbose(
                 "FreeNAS ISCSI TARGET_TO_EXTENT: %j",
                 targetToExtent
               );
@@ -1208,7 +1208,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                 }
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
+              callContext.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
               await httpApiClient.DatasetSet(datasetName, {
@@ -1273,7 +1273,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                 );
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
+              callContext.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
 
               await httpApiClient.DatasetSet(datasetName, {
                 [FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME]: extent.id,
@@ -1330,7 +1330,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                   `unknown error creating iscsi targetextent`
                 );
               }
-              this.ctx.logger.verbose(
+              callContext.logger.verbose(
                 "FreeNAS ISCSI TARGET_TO_EXTENT: %j",
                 targetToExtent
               );
@@ -1351,7 +1351,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
         // iqn = target
         let iqn = basename + ":" + iscsiName;
-        this.ctx.logger.info("FreeNAS iqn: " + iqn);
+        callContext.logger.info("FreeNAS iqn: " + iqn);
 
         // store this off to make delete process more bullet proof
         await httpApiClient.DatasetSet(datasetName, {
@@ -1405,7 +1405,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           }
           throw err;
         }
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         shareId = properties[FREENAS_NFS_SHARE_PROPERTY_NAME].value;
 
@@ -1507,7 +1507,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           }
           throw err;
         }
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         shareId = properties[FREENAS_SMB_SHARE_PROPERTY_NAME].value;
 
@@ -1618,7 +1618,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           throw err;
         }
 
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         let targetId = properties[FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME].value;
         let extentId = properties[FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME].value;
@@ -1684,7 +1684,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                     _.get(response, "body.errno") == 14
                   ) {
                     retries++;
-                    this.ctx.logger.debug(
+                    callContext.logger.debug(
                       "target: %s is in use, retry %s shortly",
                       targetId,
                       retries
@@ -1709,7 +1709,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                     FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME
                   );
                 } else {
-                  this.ctx.logger.debug(
+                  callContext.logger.debug(
                     "not deleting iscsitarget asset as it appears ID %s has been re-used: zfs name - %s, iscsitarget name - %s",
                     targetId,
                     iscsiName,
@@ -1771,7 +1771,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
                     FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME
                   );
                 } else {
-                  this.ctx.logger.debug(
+                  callContext.logger.debug(
                     "not deleting iscsiextent asset as it appears ID %s has been re-used: zfs name - %s, iscsiextent name - %s",
                     extentId,
                     iscsiName,
@@ -1833,7 +1833,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
             command = (await this.getSudoPath()) + " " + command;
           }
 
-          this.ctx.logger.verbose(
+          callContext.logger.verbose(
             "FreeNAS reloading iscsi daemon: %s",
             command
           );
@@ -1887,7 +1887,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     return volume_status;
   }
 
-  async populateCsiVolumeFromData(row) {
+  async populateCsiVolumeFromData(callContext, row) {
     const driver = this;
     const zb = await this.getZetabyte();
     const driverZfsResourceType = this.getDriverZfsResourceType();
@@ -1901,7 +1901,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     if (
       !zb.helpers.isPropertyValueSet(row[SHARE_VOLUME_CONTEXT_PROPERTY_NAME])
     ) {
-      driver.ctx.logger.warn(`${row.name} is missing share context`);
+      callContext.logger.warn(`${row.name} is missing share context`);
       return;
     }
 
@@ -2082,9 +2082,9 @@ class FreeNASApiDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(capabilities, callContext) {
     const driverZfsResourceType = this.getDriverZfsResourceType();
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     //[{"access_mode":{"mode":"SINGLE_NODE_WRITER"},"mount":{"mount_flags":["noatime","_netdev"],"fs_type":"nfs"},"access_type":"mount"}]
@@ -2177,7 +2177,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(call, callContext) {
     const driver = this;
     const httpApiClient = await driver.getTrueNASHttpApiClient();
 
@@ -2254,7 +2254,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -2403,7 +2403,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     if (driverZfsResourceType == "volume") {
       let extentDiskName = "zvol/" + datasetName;
       let maxZvolNameLength = await driver.getMaxZvolNameLength();
-      driver.ctx.logger.debug("max zvol name length: %s", maxZvolNameLength);
+      callContext.logger.debug("max zvol name length: %s", maxZvolNameLength);
       if (extentDiskName.length > maxZvolNameLength) {
         throw new GrpcError(
           grpc.status.FAILED_PRECONDITION,
@@ -2495,7 +2495,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
               volume_id;
           }
 
-          driver.ctx.logger.debug("full snapshot name: %s", fullSnapshotName);
+          callContext.logger.debug("full snapshot name: %s", fullSnapshotName);
 
           if (!zb.helpers.isZfsSnapshot(volume_content_source_snapshot_id)) {
             try {
@@ -2656,7 +2656,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
             VOLUME_SOURCE_CLONE_SNAPSHOT_PREFIX +
             volume_id;
 
-          driver.ctx.logger.debug("full snapshot name: %s", fullSnapshotName);
+            callContext.logger.debug("full snapshot name: %s", fullSnapshotName);
 
           // create snapshot
           try {
@@ -2841,7 +2841,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
           VOLUME_CONTENT_SOURCE_TYPE_PROPERTY_NAME,
           VOLUME_CONTENT_SOURCE_ID_PROPERTY_NAME,
         ]);
-        driver.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         // set mode
         let perms = {
@@ -3045,7 +3045,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       }
     }
 
-    driver.ctx.logger.debug("dataset properties: %j", properties);
+    callContext.logger.debug("dataset properties: %j", properties);
 
     // deleteStrategy
     const delete_strategy = _.get(
@@ -3070,7 +3070,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
         .extractSnapshotName(properties.origin.value)
         .startsWith(VOLUME_SOURCE_CLONE_SNAPSHOT_PREFIX)
     ) {
-      driver.ctx.logger.debug(
+      callContext.logger.debug(
         "removing with defer source snapshot: %s",
         properties.origin.value
       );
@@ -3133,7 +3133,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -3254,7 +3254,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
@@ -3269,7 +3269,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(call.request.volume_capabilities, callContext);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -3302,7 +3302,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerGetVolume(call) {
+  async ControllerGetVolume(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -3358,8 +3358,8 @@ class FreeNASApiDriver extends CsiBaseDriver {
       row[p] = response[p].rawvalue;
     }
 
-    driver.ctx.logger.debug("list volumes result: %j", row);
-    let volume = await driver.populateCsiVolumeFromData(row);
+    callContext.logger.debug("list volumes result: %j", row);
+    let volume = await driver.populateCsiVolumeFromData(callContext, row);
     let status = await driver.getVolumeStatus(datasetName);
 
     let res = { volume };
@@ -3376,7 +3376,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpClient = await this.getHttpClient();
@@ -3475,7 +3475,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       }
     }
 
-    driver.ctx.logger.debug("list volumes result: %j", rows);
+    callContext.logger.debug("list volumes result: %j", rows);
 
     entries = [];
     for (let row of rows) {
@@ -3489,7 +3489,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
         ""
       );
 
-      let volume = await driver.populateCsiVolumeFromData(row);
+      let volume = await driver.populateCsiVolumeFromData(callContext, row);
       if (volume) {
         let status = await driver.getVolumeStatus(volume_id);
         entries.push({
@@ -3518,7 +3518,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpClient = await this.getHttpClient();
@@ -3935,7 +3935,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpClient = await this.getHttpClient();
@@ -4005,7 +4005,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       source_volume_id;
     snapshotProperties[MANAGED_PROPERTY_NAME] = "true";
 
-    driver.ctx.logger.verbose("requested snapshot name: %s", name);
+    callContext.logger.verbose("requested snapshot name: %s", name);
 
     let invalid_chars;
     invalid_chars = name.match(/[^a-z0-9_\-:.+]+/gi);
@@ -4022,7 +4022,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     // https://stackoverflow.com/questions/32106243/regex-to-remove-all-non-alpha-numeric-and-replace-spaces-with/32106277
     name = name.replace(/[^a-z0-9_\-:.+]+/gi, "");
 
-    driver.ctx.logger.verbose("cleansed snapshot name: %s", name);
+    callContext.logger.verbose("cleansed snapshot name: %s", name);
 
     // check for other snapshopts with the same name on other volumes and fail as appropriate
     {
@@ -4107,7 +4107,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       fullSnapshotName = datasetName + "@" + name;
     }
 
-    driver.ctx.logger.verbose("full snapshot name: %s", fullSnapshotName);
+    callContext.logger.verbose("full snapshot name: %s", fullSnapshotName);
 
     if (detachedSnapshot) {
       tmpSnapshotName =
@@ -4266,7 +4266,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       );
     }
 
-    driver.ctx.logger.verbose("snapshot properties: %j", properties);
+    callContext.logger.verbose("snapshot properties: %j", properties);
 
     // TODO: properly handle use-case where datasetEnableQuotas is not turned on
     if (driverZfsResourceType == "filesystem") {
@@ -4333,7 +4333,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(call, callContext) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
@@ -4365,7 +4365,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
     const fullSnapshotName = datasetParentName + "/" + snapshot_id;
 
-    driver.ctx.logger.verbose("deleting snapshot: %s", fullSnapshotName);
+    callContext.logger.verbose("deleting snapshot: %s", fullSnapshotName);
 
     if (detachedSnapshot) {
       try {
@@ -4413,7 +4413,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
 
@@ -4450,7 +4450,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       }
     }
 
-    const result = this.assertCapabilities(capabilities);
+    const result = this.assertCapabilities(capabilities, callContext);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -174,7 +174,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} datasetName
    */
-  async createShare(call, datasetName) {
+  async createShare(callContext, call, datasetName) {
     const driver = this;
     const driverShareType = this.getDriverShareType();
     const httpClient = await this.getHttpClient();
@@ -879,7 +879,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
               this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME]: target.id,
               });
 
@@ -1378,7 +1378,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
   }
 
-  async deleteShare(call, datasetName) {
+  async deleteShare(callContext, call, datasetName) {
     const driverShareType = this.getDriverShareType();
     const httpClient = await this.getHttpClient();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -1809,7 +1809,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    * @param {*} datasetName
    * @returns
    */
-  async expandVolume(call, datasetName) {
+  async expandVolume(callContext, call, datasetName) {
     // TODO: fix me
     return;
     const driverShareType = this.getDriverShareType();
@@ -2228,7 +2228,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(call, callContext) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -2957,7 +2957,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
         break;
     }
 
-    volume_context = await this.createShare(call, datasetName);
+    volume_context = await this.createShare(callContext, call, datasetName);
     await httpApiClient.DatasetSet(datasetName, {
       [SHARE_VOLUME_CONTEXT_PROPERTY_NAME]: JSON.stringify(volume_context),
     });
@@ -3000,7 +3000,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(call, callContext) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
@@ -3059,7 +3059,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
 
     // remove share resources
-    await this.deleteShare(call, datasetName);
+    await this.deleteShare(callContext, call, datasetName);
 
     // remove parent snapshot if appropriate with defer
     if (
@@ -3237,7 +3237,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       await httpApiClient.DatasetSet(datasetName, properties);
     }
 
-    await this.expandVolume(call, datasetName);
+    await this.expandVolume(callContext, call, datasetName);
 
     return {
       capacity_bytes:

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -284,7 +284,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
           FREENAS_NFS_SHARE_PROPERTY_NAME,
         ]);
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         // create nfs share
         if (
@@ -495,7 +495,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
           FREENAS_SMB_SHARE_PROPERTY_NAME,
         ]);
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         let smbName;
 
@@ -518,7 +518,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
         smbName = smbName.toLowerCase();
 
-        this.ctx.logger.info(
+        callContext.logger.info(
           "FreeNAS creating smb share with name: " + smbName
         );
 
@@ -744,7 +744,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
           FREENAS_ISCSI_TARGETTOEXTENT_ID_PROPERTY_NAME,
         ]);
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         let basename;
         let iscsiName;
@@ -774,7 +774,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
         let extentDiskName = "zvol/" + datasetName;
         let maxZvolNameLength = await driver.getMaxZvolNameLength();
-        driver.ctx.logger.debug("max zvol name length: %s", maxZvolNameLength);
+        callContext.logger.debug("max zvol name length: %s", maxZvolNameLength);
 
         /**
          * limit is a FreeBSD limitation
@@ -796,7 +796,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
           );
         }
 
-        this.ctx.logger.info(
+        callContext.logger.info(
           "FreeNAS creating iscsi assets with name: " + iscsiName
         );
 
@@ -870,7 +870,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
               );
             }
             basename = response.body.iscsi_basename;
-            this.ctx.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
+            callContext.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
             break;
           case 2:
             response = await httpClient.get("/iscsi/global");
@@ -883,7 +883,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
               );
             }
             basename = response.body.basename;
-            this.ctx.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
+            callContext.logger.verbose("FreeNAS ISCSI BASENAME: " + basename);
             break;
           default:
             throw new GrpcError(
@@ -953,7 +953,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 );
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
+              callContext.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
               await zb.zfs.set(callContext, datasetName, {
@@ -1035,7 +1035,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   );
                 }
 
-                this.ctx.logger.verbose(
+                callContext.logger.verbose(
                   "FreeNAS ISCSI TARGET_GROUP: %j",
                   targetGroup
                 );
@@ -1101,7 +1101,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 );
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
+              callContext.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
 
               await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME]: extent.id,
@@ -1159,7 +1159,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   `unknown error creating iscsi targettoextent`
                 );
               }
-              this.ctx.logger.verbose(
+              callContext.logger.verbose(
                 "FreeNAS ISCSI TARGET_TO_EXTENT: %j",
                 targetToExtent
               );
@@ -1285,7 +1285,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 }
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
+              callContext.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
               await zb.zfs.set(callContext, datasetName, {
@@ -1350,7 +1350,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 );
               }
 
-              this.ctx.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
+              callContext.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
 
               await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME]: extent.id,
@@ -1407,7 +1407,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   `unknown error creating iscsi targetextent`
                 );
               }
-              this.ctx.logger.verbose(
+              callContext.logger.verbose(
                 "FreeNAS ISCSI TARGET_TO_EXTENT: %j",
                 targetToExtent
               );
@@ -1428,7 +1428,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
         // iqn = target
         let iqn = basename + ":" + iscsiName;
-        this.ctx.logger.info("FreeNAS iqn: " + iqn);
+        callContext.logger.info("FreeNAS iqn: " + iqn);
 
         // store this off to make delete process more bullet proof
         await zb.zfs.set(callContext, datasetName, {
@@ -1482,7 +1482,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
           throw err;
         }
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         shareId = properties[FREENAS_NFS_SHARE_PROPERTY_NAME].value;
 
@@ -1586,7 +1586,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
           throw err;
         }
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         shareId = properties[FREENAS_SMB_SHARE_PROPERTY_NAME].value;
 
@@ -1699,7 +1699,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
         }
 
         properties = properties[datasetName];
-        this.ctx.logger.debug("zfs props data: %j", properties);
+        callContext.logger.debug("zfs props data: %j", properties);
 
         let targetId = properties[FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME].value;
         let extentId = properties[FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME].value;
@@ -1765,7 +1765,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                     _.get(response, "body.errno") == 14
                   ) {
                     retries++;
-                    this.ctx.logger.debug(
+                    callContext.logger.debug(
                       "target: %s is in use, retry %s shortly",
                       targetId,
                       retries
@@ -1791,7 +1791,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                     FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME
                   );
                 } else {
-                  this.ctx.logger.debug(
+                  callContext.logger.debug(
                     "not deleting iscsitarget asset as it appears ID %s has been re-used: zfs name - %s, iscsitarget name - %s",
                     targetId,
                     iscsiName,
@@ -1854,7 +1854,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                     FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME
                   );
                 } else {
-                  this.ctx.logger.debug(
+                  callContext.logger.debug(
                     "not deleting iscsiextent asset as it appears ID %s has been re-used: zfs name - %s, iscsiextent name - %s",
                     extentId,
                     iscsiName,
@@ -2033,7 +2033,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
             FREENAS_ISCSI_ASSETS_NAME_PROPERTY_NAME,
           ]);
           properties = properties[datasetName];
-          this.ctx.logger.debug("zfs props data: %j", properties);
+          callContext.logger.debug("zfs props data: %j", properties);
           let iscsiName =
             properties[FREENAS_ISCSI_ASSETS_NAME_PROPERTY_NAME].value;
 
@@ -2067,7 +2067,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
               reload = true;
               break;
             case 2:
-              this.ctx.logger.verbose(
+              callContext.logger.verbose(
                 "FreeNAS reloading iscsi daemon using api"
               );
               // POST /service/reload
@@ -2100,7 +2100,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
             command = (await this.getSudoPath()) + " " + command;
           }
 
-          this.ctx.logger.verbose(
+          callContext.logger.verbose(
             "FreeNAS reloading iscsi daemon: %s",
             command
           );

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -35,7 +35,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(call, callContext) {
     const driver = this;
 
     if (driver.ctx.args.csiMode.includes("controller")) {

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -249,7 +249,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} datasetName
    */
-  async createShare(call, datasetName) {
+  async createShare(callContext, call, datasetName) {
     const driver = this;
     const driverShareType = this.getDriverShareType();
     const execClient = this.getExecClient();
@@ -279,7 +279,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
     switch (driverShareType) {
       case "nfs":
-        properties = await zb.zfs.get(datasetName, [
+        properties = await zb.zfs.get(callContext, datasetName, [
           "mountpoint",
           FREENAS_NFS_SHARE_PROPERTY_NAME,
         ]);
@@ -413,7 +413,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 }
 
                 //set zfs property
-                await zb.zfs.set(datasetName, {
+                await zb.zfs.set(callContext, datasetName, {
                   [FREENAS_NFS_SHARE_PROPERTY_NAME]: response.body.id,
                 });
               } else {
@@ -456,7 +456,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   }
 
                   //set zfs property
-                  await zb.zfs.set(datasetName, {
+                  await zb.zfs.set(callContext, datasetName, {
                     [FREENAS_NFS_SHARE_PROPERTY_NAME]: lookupShare.id,
                   });
                 } else {
@@ -490,7 +490,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
        * ensuring the path is valid and the shareName
        */
       case "smb":
-        properties = await zb.zfs.get(datasetName, [
+        properties = await zb.zfs.get(callContext, datasetName, [
           "mountpoint",
           FREENAS_SMB_SHARE_PROPERTY_NAME,
         ]);
@@ -667,7 +667,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 }
 
                 //set zfs property
-                await zb.zfs.set(datasetName, {
+                await zb.zfs.set(callContext, datasetName, {
                   [FREENAS_SMB_SHARE_PROPERTY_NAME]: response.body.id,
                 });
               } else {
@@ -708,7 +708,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   }
 
                   //set zfs property
-                  await zb.zfs.set(datasetName, {
+                  await zb.zfs.set(callContext, datasetName, {
                     [FREENAS_SMB_SHARE_PROPERTY_NAME]: lookupShare.id,
                   });
                 } else {
@@ -738,7 +738,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
         break;
       case "iscsi":
-        properties = await zb.zfs.get(datasetName, [
+        properties = await zb.zfs.get(callContext, datasetName, [
           FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME,
           FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME,
           FREENAS_ISCSI_TARGETTOEXTENT_ID_PROPERTY_NAME,
@@ -956,7 +956,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
               this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME]: target.id,
               });
 
@@ -1103,7 +1103,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
               this.ctx.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
 
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME]: extent.id,
               });
 
@@ -1164,7 +1164,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 targetToExtent
               );
 
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_TARGETTOEXTENT_ID_PROPERTY_NAME]:
                   targetToExtent.id,
               });
@@ -1288,7 +1288,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
               this.ctx.logger.verbose("FreeNAS ISCSI TARGET: %j", target);
 
               // set target.id on zvol
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME]: target.id,
               });
 
@@ -1352,7 +1352,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
               this.ctx.logger.verbose("FreeNAS ISCSI EXTENT: %j", extent);
 
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME]: extent.id,
               });
 
@@ -1412,7 +1412,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                 targetToExtent
               );
 
-              await zb.zfs.set(datasetName, {
+              await zb.zfs.set(callContext, datasetName, {
                 [FREENAS_ISCSI_TARGETTOEXTENT_ID_PROPERTY_NAME]:
                   targetToExtent.id,
               });
@@ -1431,7 +1431,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
         this.ctx.logger.info("FreeNAS iqn: " + iqn);
 
         // store this off to make delete process more bullet proof
-        await zb.zfs.set(datasetName, {
+        await zb.zfs.set(callContext, datasetName, {
           [FREENAS_ISCSI_ASSETS_NAME_PROPERTY_NAME]: iscsiName,
         });
 
@@ -1455,7 +1455,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
     }
   }
 
-  async deleteShare(call, datasetName) {
+  async deleteShare(callContext, call, datasetName) {
     const driverShareType = this.getDriverShareType();
     const httpClient = await this.getHttpClient();
     const apiVersion = httpClient.getApiVersion();
@@ -1471,7 +1471,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
     switch (driverShareType) {
       case "nfs":
         try {
-          properties = await zb.zfs.get(datasetName, [
+          properties = await zb.zfs.get(callContext, datasetName, [
             "mountpoint",
             FREENAS_NFS_SHARE_PROPERTY_NAME,
           ]);
@@ -1558,6 +1558,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   // remove property to prevent delete race conditions
                   // due to id re-use by FreeNAS/TrueNAS
                   await zb.zfs.inherit(
+                    callContext,
                     datasetName,
                     FREENAS_NFS_SHARE_PROPERTY_NAME
                   );
@@ -1574,7 +1575,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
         break;
       case "smb":
         try {
-          properties = await zb.zfs.get(datasetName, [
+          properties = await zb.zfs.get(callContext, datasetName, [
             "mountpoint",
             FREENAS_SMB_SHARE_PROPERTY_NAME,
           ]);
@@ -1663,6 +1664,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   // remove property to prevent delete race conditions
                   // due to id re-use by FreeNAS/TrueNAS
                   await zb.zfs.inherit(
+                    callContext,
                     datasetName,
                     FREENAS_SMB_SHARE_PROPERTY_NAME
                   );
@@ -1683,7 +1685,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
         // Delete extent
         try {
-          properties = await zb.zfs.get(datasetName, [
+          properties = await zb.zfs.get(callContext, datasetName, [
             FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME,
             FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME,
             FREENAS_ISCSI_TARGETTOEXTENT_ID_PROPERTY_NAME,
@@ -1784,6 +1786,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   // remove property to prevent delete race conditions
                   // due to id re-use by FreeNAS/TrueNAS
                   await zb.zfs.inherit(
+                    callContext,
                     datasetName,
                     FREENAS_ISCSI_TARGET_ID_PROPERTY_NAME
                   );
@@ -1846,6 +1849,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
                   // remove property to prevent delete race conditions
                   // due to id re-use by FreeNAS/TrueNAS
                   await zb.zfs.inherit(
+                    callContext,
                     datasetName,
                     FREENAS_ISCSI_EXTENT_ID_PROPERTY_NAME
                   );
@@ -2011,7 +2015,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
     }
   }
 
-  async expandVolume(call, datasetName) {
+  async expandVolume(callContext, call, datasetName) {
     const driverShareType = this.getDriverShareType();
     const execClient = this.getExecClient();
     const httpClient = await this.getHttpClient();
@@ -2025,7 +2029,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
         let reload = false;
         if (isScale) {
           let properties;
-          properties = await zb.zfs.get(datasetName, [
+          properties = await zb.zfs.get(callContext, datasetName, [
             FREENAS_ISCSI_ASSETS_NAME_PROPERTY_NAME,
           ]);
           properties = properties[datasetName];

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -767,7 +767,7 @@ class CsiBaseDriver {
     }
 
     if (call.request.volume_context.provisioner_driver == "node-manual") {
-      result = await this.assertCapabilities([capability], node_attach_driver);
+      result = await this.assertCapabilities([capability], callContext, node_attach_driver);
       if (!result.valid) {
         throw new GrpcError(
           grpc.status.INVALID_ARGUMENT,

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -1389,8 +1389,8 @@ class CsiBaseDriver {
           case "zfs-local":
             // TODO: make this a geneic zb instance (to ensure works with node-manual driver)
             const zb = driver.getDefaultZetabyteInstance();
-            result = await zb.zfs.get(`${volume_context.zfs_asset_name}`, [
-              "type",
+            "type",
+            result = await zb.zfs.get(callContext, `${volume_context.zfs_asset_name}`, [
               "mountpoint",
             ]);
             result = result[`${volume_context.zfs_asset_name}`];
@@ -1399,7 +1399,7 @@ class CsiBaseDriver {
                 if (result.mountpoint.value != "legacy") {
                   // zfs set mountpoint=legacy <dataset>
                   // zfs inherit mountpoint <dataset>
-                  await zb.zfs.set(`${volume_context.zfs_asset_name}`, {
+                  await zb.zfs.set(callContext, `${volume_context.zfs_asset_name}`, {
                     mountpoint: "legacy",
                   });
                 }

--- a/src/driver/node-manual/index.js
+++ b/src/driver/node-manual/index.js
@@ -100,8 +100,8 @@ class NodeManualDriver extends CsiBaseDriver {
     }
   }
 
-  assertCapabilities(capabilities, node_attach_driver) {
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+  assertCapabilities(capabilities, callContext, node_attach_driver) {
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     let driverResourceType;

--- a/src/driver/node-manual/index.js
+++ b/src/driver/node-manual/index.js
@@ -242,7 +242,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -253,7 +253,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -264,7 +264,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -275,7 +275,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -286,7 +286,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -297,7 +297,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -308,7 +308,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -319,7 +319,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -330,7 +330,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`

--- a/src/driver/zfs-local-ephemeral-inline/index.js
+++ b/src/driver/zfs-local-ephemeral-inline/index.js
@@ -165,10 +165,10 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     return datasetParentName;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(capabilities, callContext) {
     // hard code this for now
     const driverZfsResourceType = "filesystem";
-    this.ctx.logger.verbose("validating capabilities: %j", capabilities);
+    callContext.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;
     //[{"access_mode":{"mode":"SINGLE_NODE_WRITER"},"mount":{"mount_flags":["noatime","_netdev"],"fs_type":"nfs"},"access_type":"mount"}]
@@ -272,7 +272,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodePublishVolume(call) {
+  async NodePublishVolume(call, callContext) {
     const driver = this;
     const zb = this.getZetabyte();
 
@@ -386,7 +386,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodeUnpublishVolume(call) {
+  async NodeUnpublishVolume(call, callContext) {
     const zb = this.getZetabyte();
     const filesystem = new Filesystem();
     let result;
@@ -454,7 +454,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(call, callContext) {
     const driver = this;
     const zb = this.getZetabyte();
 
@@ -488,7 +488,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(call, callContext) {
     const driver = this;
     const result = this.assertCapabilities(call.request.volume_capabilities);
 

--- a/src/driver/zfs-local-ephemeral-inline/index.js
+++ b/src/driver/zfs-local-ephemeral-inline/index.js
@@ -368,7 +368,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     }
 
     // TODO: catch out of space errors and return specifc grpc message?
-    await zb.zfs.create(datasetName, {
+    await zb.zfs.create(callContext, datasetName, {
       parents: true,
       properties: volumeProperties,
     });
@@ -424,7 +424,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     // NOTE: -R will recursively delete items + dependent filesets
     // delete dataset
     try {
-      await zb.zfs.destroy(datasetName, { recurse: true, force: true });
+      await zb.zfs.destroy(callContext, datasetName, { recurse: true, force: true });
     } catch (err) {
       if (err.toString().includes("filesystem has dependent clones")) {
         throw new GrpcError(
@@ -478,7 +478,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     const datasetName = datasetParentName;
 
     let properties;
-    properties = await zb.zfs.get(datasetName, ["avail"]);
+    properties = await zb.zfs.get(callContext, datasetName, ["avail"]);
     properties = properties[datasetName];
 
     return { available_capacity: properties.available.value };

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -92,6 +92,49 @@ function lockKeysFromRequest(call, serviceMethodName) {
   }
 }
 
+function loggerIdFromRequest(call, serviceMethodName) {
+  switch (serviceMethodName) {
+    // controller
+    case "CreateVolume":
+      return call.request.name;
+    case "DeleteVolume":
+    case "ControllerExpandVolume":
+    case "ControllerPublishVolume":
+    case "ControllerUnpublishVolume":
+    case "ValidateVolumeCapabilities":
+    case "ControllerGetVolume":
+    case "ControllerModifyVolume":
+      return call.request.volume_id;
+    case "CreateSnapshot":
+      return call.request.source_volume_id;
+    case "DeleteSnapshot":
+      return call.request.snapshot_id;
+    case "ListVolumes":
+    case "GetCapacity":
+    case "ControllerGetCapabilities":
+    case "ListSnapshots":
+      return '';
+
+    // node
+    case "NodeStageVolume":
+    case "NodeUnstageVolume":
+    case "NodePublishVolume":
+    case "NodeUnpublishVolume":
+    case "NodeGetVolumeStats":
+    case "NodeExpandVolume":
+      return call.request.volume_id;
+
+    case "NodeGetCapabilities":
+    case "NodeGetInfo":
+    case "GetPluginInfo":
+    case "GetPluginCapabilities":
+    case "Probe":
+      return '';
+    default:
+      throw `loggerIdFromRequest: unknown method: ${serviceMethodName}`;
+  }
+}
+
 function getLargestNumber() {
   let number;
   for (let i = 0; i < arguments.length; i++) {
@@ -278,6 +321,7 @@ module.exports.crc32 = crc32;
 module.exports.crc16 = crc16;
 module.exports.crc8 = crc8;
 module.exports.lockKeysFromRequest = lockKeysFromRequest;
+module.exports.loggerIdFromRequest = loggerIdFromRequest;
 module.exports.getLargestNumber = getLargestNumber;
 module.exports.stringify = stringify;
 module.exports.before_string = before_string;

--- a/src/utils/zfs.js
+++ b/src/utils/zfs.js
@@ -911,8 +911,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} options
        */
-      create: function (dataset, options = {}) {
-        if (!(arguments.length >= 1)) throw new (Error("Invalid arguments"))();
+      create: function (callContext, dataset, options = {}) {
+        if (!(arguments.length >= 2)) throw new (Error("Invalid arguments"))();
 
         return new Promise((resolve, reject) => {
           const idempotent =
@@ -962,8 +962,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} options
        */
-      destroy: function (dataset, options = {}) {
-        if (!(arguments.length >= 1)) throw Error("Invalid arguments");
+      destroy: function (callContext, dataset, options = {}) {
+        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           const idempotent =
@@ -1013,8 +1013,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} options
        */
-      snapshot: function (dataset, options = {}) {
-        if (!(arguments.length >= 1)) throw Error("Invalid arguments");
+      snapshot: function (callContext, dataset, options = {}) {
+        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           const idempotent =
@@ -1061,8 +1061,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} options
        */
-      rollback: function (dataset, options = {}) {
-        if (!(arguments.length >= 1)) throw Error("Invalid arguments");
+      rollback: function (callContext, dataset, options = {}) {
+        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -1095,8 +1095,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} options
        */
-      clone: function (snapshot, dataset, options = {}) {
-        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
+      clone: function (callContext, snapshot, dataset, options = {}) {
+        if (!(arguments.length >= 3)) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           const idempotent =
@@ -1143,8 +1143,8 @@ class Zetabyte {
        * @param {*} target
        * @param {*} receive_options
        */
-      send_receive(source, send_options = [], target, receive_options = []) {
-        if (arguments.length < 4) throw Error("Invalid arguments");
+      send_receive(callContext, source, send_options = [], target, receive_options = []) {
+        if (arguments.length < 5) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           // specially handle sudo here to avoid the need for using sudo on the whole script
@@ -1187,8 +1187,8 @@ class Zetabyte {
        *
        * @param {*} dataset
        */
-      promote: function (dataset) {
-        if (arguments.length != 1) throw Error("Invalid arguments");
+      promote: function (callContext, dataset) {
+        if (arguments.length != 2) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -1217,8 +1217,8 @@ class Zetabyte {
        * @param {*} target
        * @param {*} options
        */
-      rename: function (source, target, options = {}) {
-        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
+      rename: function (callContext, source, target, options = {}) {
+        if (!(arguments.length >= 3)) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -1251,8 +1251,8 @@ class Zetabyte {
        * @param {*} properties
        * @param {*} options
        */
-      list: function (dataset, properties, options = {}) {
-        if (!(arguments.length >= 1)) throw Error("Invalid arguments");
+      list: function (callContext, dataset, properties, options = {}) {
+        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
         if (!properties) properties = zb.DEFAULT_ZFS_LIST_PROPERTIES;
 
         return new Promise((resolve, reject) => {
@@ -1317,8 +1317,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} properties
        */
-      set: function (dataset, properties) {
-        if (arguments.length != 2) throw Error("Invalid arguments");
+      set: function (callContext, dataset, properties) {
+        if (arguments.length != 3) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           if (!Object.keys(properties).length) {
@@ -1361,8 +1361,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} properties
        */
-      get: function (dataset, properties = "all", options = {}) {
-        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
+      get: function (callContext, dataset, properties = "all", options = {}) {
+        if (!(arguments.length >= 3)) throw Error("Invalid arguments");
         if (!properties) properties = "all";
         if (Array.isArray(properties) && !properties.length > 0)
           properties = "all";
@@ -1445,8 +1445,8 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} property
        */
-      inherit: function (dataset, property) {
-        if (arguments.length != 2) throw Error("Invalid arguments");
+      inherit: function (callContext, dataset, property) {
+        if (arguments.length != 3) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -1473,8 +1473,8 @@ class Zetabyte {
        *
        * @param {*} dataset
        */
-      remap: function (dataset) {
-        if (arguments.length != 1) throw Error("Invalid arguments");
+      remap: function (callContext, dataset) {
+        if (arguments.length != 2) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -1499,7 +1499,7 @@ class Zetabyte {
        *
        * @param {*} dataset
        */
-      upgrade: function (options = {}, dataset) {
+      upgrade: function (callContext, options = {}, dataset) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("upgrade");

--- a/src/utils/zfs.js
+++ b/src/utils/zfs.js
@@ -238,7 +238,7 @@ class Zetabyte {
        * @param {*} pool
        * @param {*} vdevs
        */
-      add: function (pool, vdevs) {
+      add: function (callContext, pool, vdevs) {
         // -f force
         // -n noop
       },
@@ -250,7 +250,7 @@ class Zetabyte {
        * @param {*} device
        * @param {*} new_device
        */
-      attach: function (pool, device, new_device) {
+      attach: function (callContext, pool, device, new_device) {
         // -f      Forces use of new_device, even if its appears to be in use.
       },
 
@@ -259,7 +259,7 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      checkpoint: function (pool) {},
+      checkpoint: function (callContext, pool) {},
 
       /**
        * zpool clear [-F [-n]] pool [device]
@@ -267,7 +267,7 @@ class Zetabyte {
        * @param {*} pool
        * @param {*} device
        */
-      clear: function (pool, device) {},
+      clear: function (callContext, pool, device) {},
 
       /**
        * zpool create [-fnd] [-o property=value] ... [-O
@@ -278,8 +278,8 @@ class Zetabyte {
        * zpool create command, including log devices, cache devices, and hot spares.
        * The input is an object of the form produced by the disklayout library.
        */
-      create: function (pool, options) {
-        if (arguments.length != 2)
+      create: function (callContext, pool, options) {
+        if (arguments.length != 3)
           throw Error("Invalid arguments, 2 arguments required");
 
         return new Promise((resolve, reject) => {
@@ -357,8 +357,8 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      destroy: function (pool) {
-        if (arguments.length != 1) throw Error("Invalid arguments");
+      destroy: function (callContext, pool) {
+        if (arguments.length != 2) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -384,8 +384,8 @@ class Zetabyte {
        * @param {*} pool
        * @param {*} device
        */
-      detach: function (pool, device) {
-        if (arguments.length != 2) throw Error("Invalid arguments");
+      detach: function (callContext, pool, device) {
+        if (arguments.length != 3) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
           let args = [];
@@ -410,7 +410,7 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      export: function (pool) {
+      export: function (callContext, pool) {
         if (arguments.length != 2) throw Error("Invalid arguments");
 
         return new Promise((resolve, reject) => {
@@ -440,14 +440,14 @@ class Zetabyte {
       /**
        * zpool get [-Hp] [-o field[,...]] all | property[,...] pool ...
        */
-      get: function () {},
+      get: function (callContext) {},
 
       /**
        * zpool history [-il] [pool] ...
        *
        * @param {*} pool
        */
-      history: function (pool) {
+      history: function (callContext, pool) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("history");
@@ -486,7 +486,7 @@ class Zetabyte {
        *
        * @param {*} options
        */
-      import: function (options = {}) {
+      import: function (callContext, options = {}) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("import");
@@ -511,14 +511,14 @@ class Zetabyte {
        *
        * @param {*} options
        */
-      iostat: function (options = {}) {},
+      iostat: function (callContext, options = {}) {},
 
       /**
        * zpool labelclear [-f] device
        *
        * @param {*} device
        */
-      labelclear: function (device) {},
+      labelclear: function (callContext, device) {},
 
       /**
        * zpool list [-Hpv] [-o property[,...]] [-T d|u] [pool] ... [inverval
@@ -527,8 +527,8 @@ class Zetabyte {
        * @param {*} pool
        * @param {*} options
        */
-      list: function (pool, properties, options = {}) {
-        if (!(arguments.length >= 1)) throw Error("Invalid arguments");
+      list: function (callContext, pool, properties, options = {}) {
+        if (!(arguments.length >= 2)) throw Error("Invalid arguments");
         if (!properties) properties = zb.DEFAULT_ZPOOL_LIST_PROPERTIES;
 
         return new Promise((resolve, reject) => {
@@ -594,7 +594,7 @@ class Zetabyte {
        * @param {*} device
        * @param {*} options
        */
-      offline: function (pool, device, options = {}) {
+      offline: function (callContext, pool, device, options = {}) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("offline");
@@ -621,7 +621,7 @@ class Zetabyte {
        * @param {*} device
        * @param {*} options
        */
-      online: function (pool, device, options = {}) {
+      online: function (callContext, pool, device, options = {}) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("online");
@@ -646,7 +646,7 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      reguid: function (pool) {
+      reguid: function (callContext, pool) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("reguid");
@@ -672,7 +672,7 @@ class Zetabyte {
        * @param {*} pool
        * @param {*} device
        */
-      remove: function (pool, device, options = {}) {
+      remove: function (callContext, pool, device, options = {}) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("remove");
@@ -701,7 +701,7 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      reopen: function (pool) {
+      reopen: function (callContext, pool) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("reopen");
@@ -726,7 +726,7 @@ class Zetabyte {
        * @param {*} device
        * @param {*} new_device
        */
-      replace: function (pool, device, new_device) {
+      replace: function (callContext, pool, device, new_device) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("replace");
@@ -754,7 +754,7 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      scrub: function (pool) {
+      scrub: function (callContext, pool) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("scrub");
@@ -787,7 +787,7 @@ class Zetabyte {
        * @param {*} property
        * @param {*} value
        */
-      set: function (pool, property, value) {
+      set: function (callContext, pool, property, value) {
         value = escapeShell(value);
         return new Promise((resolve, reject) => {
           let args = [];
@@ -815,12 +815,12 @@ class Zetabyte {
        * @param {*} newpool
        * @param {*} device
        */
-      split: function (pool, newpool, device) {},
+      split: function (callContext, pool, newpool, device) {},
 
       /**
        * zpool status [-vx] [-T d|u] [pool] ... [interval [count]]
        */
-      status: function (pool, options = {}) {
+      status: function (callContext, pool, options = {}) {
         return new Promise((resolve, reject) => {
           let args = [];
           if (!("parse" in options)) options.parse = true;
@@ -874,7 +874,7 @@ class Zetabyte {
        *
        * @param {*} pool
        */
-      upgrade: function (pool) {
+      upgrade: function (callContext, pool) {
         return new Promise((resolve, reject) => {
           let args = [];
           args.push("upgrade");

--- a/src/utils/zfs.js
+++ b/src/utils/zfs.js
@@ -341,6 +341,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -367,6 +368,7 @@ class Zetabyte {
           args.push(pool);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -394,6 +396,7 @@ class Zetabyte {
           args.push(device);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -426,6 +429,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -462,6 +466,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -495,6 +500,7 @@ class Zetabyte {
           if (options.destroyed) args.push("-D");
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -564,6 +570,7 @@ class Zetabyte {
           if (options.count) args.push(options.count);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -603,6 +610,7 @@ class Zetabyte {
           args.push(device);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -630,6 +638,7 @@ class Zetabyte {
           args.push(device);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -653,6 +662,7 @@ class Zetabyte {
           args.push(pool);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -685,6 +695,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -708,6 +719,7 @@ class Zetabyte {
           args.push(pool);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -738,6 +750,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -769,6 +782,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -796,6 +810,7 @@ class Zetabyte {
           args.push(pool);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -841,6 +856,7 @@ class Zetabyte {
           if (options.count) args.push(options.count);
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -891,6 +907,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zpool,
             args,
             { timeout: zb.options.timeout },
@@ -938,6 +955,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -986,6 +1004,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1040,6 +1059,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1073,6 +1093,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1120,6 +1141,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1171,6 +1193,7 @@ class Zetabyte {
           args.push("'" + command.join(" ") + "'");
 
           zb.exec(
+            callContext,
             "/bin/sh",
             args,
             { timeout: zb.options.timeout, sudo: false },
@@ -1196,6 +1219,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1231,6 +1255,7 @@ class Zetabyte {
           args.push(target);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1288,6 +1313,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1338,6 +1364,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1425,6 +1452,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1457,6 +1485,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1482,6 +1511,7 @@ class Zetabyte {
           args.push(dataset);
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1512,6 +1542,7 @@ class Zetabyte {
           }
 
           zb.exec(
+            callContext,
             zb.options.paths.zfs,
             args,
             { timeout: zb.options.timeout },
@@ -1529,13 +1560,13 @@ class Zetabyte {
    * Should be a matching interface for spawn roughly
    *
    */
-  exec() {
+  exec(callContext) {
     const zb = this;
-    let command = arguments[0];
+    let command = arguments[1];
     let args, options, callback, timeout;
     let stdout = "";
     let stderr = "";
-    switch (arguments.length) {
+    switch (arguments.length - 1) {
       case 1:
         break;
       case 2:
@@ -1571,12 +1602,12 @@ class Zetabyte {
     }
 
     if (zb.options.log_commands) {
-      if (typeof zb.options.logger.verbose != "function") {
-        zb.options.logger.verbose = function () {
+      if (typeof callContext.logger.verbose != "function") {
+        callContext.logger.verbose = function () {
           console.debug(...arguments);
         };
       }
-      zb.options.logger.verbose(
+      callContext.logger.verbose(
         `executing zfs command: ${command} ${args.join(" ")}`
       );
     }


### PR DESCRIPTION
Currently logs look like this: `{host, level, message, service, timestamp}`.

When you need to trace log entries for a certain volume, you need to search for entry with `new request` message, and follow next lines, until corresponding `new response`.

This is inconvenient in several ways:
- There is no way to filter logs. You always need to get all logs and just read them
- It's very hard to read logs when there is more than one parallel request. Lines from different requests mix, and it's sometimes impossible to tell the relationship between them.

This PR tries to improve logs: it adds new fields to log structure: `{host,level,message,method,requestId,service,timestamp,uuid}`
Now you can filter and search by method name, by request ID (the same for all requests related to a volume), by uuid (unique for each individual request).
When there are several parallel requests, uuid makes it easy to separate logs from different requests.

I tried to add these additional fields to all drivers.
Some logs still use the old style. This is mostly logs from various cached objects which are forced to use global log object, without context info.
I added log context to Zetabyte exec command, but I wasn't able to add log context to `spawn()` commands because they seem too interconnected in different places.
I didn't touch any of the other cached objects, such as http clients, Restic and Kopia clients, etc.