### PR TITLE
Add explicit driver cleanup

### DIFF
--- a/bin/democratic-csi
+++ b/bin/democratic-csi
@@ -486,6 +486,21 @@ const signalMapping = {
         }
       }
 
+      if (driver && typeof driver.getCleanupHandlers === 'function') {
+        const cleanup = driver.getCleanupHandlers();
+        console.log(`running driver ${cleanup.length} cleanup handlers`);
+        for (const c of cleanup) {
+          try {
+            c();
+          } catch (e) {
+            console.log("cleanup handler failed");
+            console.log(e);
+          }
+        }
+      } else {
+        console.log(`current driver does not support cleanup`);
+      }
+
       console.log("server fully shutdown, exiting");
       process.exit(codeNumber);
     });

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -16,10 +16,12 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
   getExecClient() {
     return this.ctx.registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
       if (this.options.sshConnection) {
-        return new SshClient({
+        const sshClient = new SshClient({
           logger: this.ctx.logger,
           connection: this.options.sshConnection,
         });
+        this.cleanup.push(() => sshClient.finalize());
+        return sshClient;
       } else {
         return new LocalCliExecClient({
           logger: this.ctx.logger,

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -57,10 +57,12 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
   getExecClient() {
     return this.ctx.registry.get(`${__REGISTRY_NS__}:exec_client`, () => {
-      return new SshClient({
+      const sshClient = new SshClient({
         logger: this.ctx.logger,
         connection: this.options.sshConnection,
       });
+      this.cleanup.push(() => sshClient.finalize());
+      return sshClient;
     });
   }
 

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -33,6 +33,7 @@ class CsiBaseDriver {
   constructor(ctx, options) {
     this.ctx = ctx;
     this.options = options || {};
+    this.cleanup = [];
 
     if (!this.options.hasOwnProperty("node")) {
       this.options.node = {};
@@ -49,6 +50,10 @@ class CsiBaseDriver {
     if (!this.options.node.mount.hasOwnProperty("checkFilesystem")) {
       this.options.node.mount.checkFilesystem = {};
     }
+  }
+
+  getCleanupHandlers() {
+    return this.cleanup;
   }
 
   /**

--- a/src/driver/zfs-local-ephemeral-inline/index.js
+++ b/src/driver/zfs-local-ephemeral-inline/index.js
@@ -125,10 +125,12 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
 
   getSshClient() {
     return this.ctx.registry.get(`${__REGISTRY_NS__}:ssh_client`, () => {
-      return new SshClient({
+      const sshClient = new SshClient({
         logger: this.ctx.logger,
         connection: this.options.sshConnection,
       });
+      this.cleanup.push(() => sshClient.finalize());
+      return sshClient;
     });
   }
 


### PR DESCRIPTION
Currently driver cleanup happens only when system removes process/container resources.
This works good enough, provided driver does not allocate any external resources.
But theoretically drivers could allocate external resources, and there is no way to remove them on exit.

In practice I found issues while developing `proxy` driver. SSH-based drivers create SSH connections that aren't closed automatically.
There may be some other resources worth cleaning up, but I don't see any critical ones for now: HTTP clients seem to be stateless, various local exec clients are also stateless.