### PR TITLE
Change driver interface: add call context arg

### DIFF
--- a/bin/democratic-csi
+++ b/bin/democratic-csi
@@ -231,7 +231,7 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
           operationLock.add(key);
         });
       }
-      response = await driver[serviceMethodName](call);
+      response = await driver[serviceMethodName](callContext, call);
     } catch (e) {
       responseError = e;
     } finally {

--- a/bin/democratic-csi
+++ b/bin/democratic-csi
@@ -118,6 +118,7 @@ const cache = new LRU({ max: 500 });
 const { logger } = require("../src/utils/logger");
 const { GrpcError } = require("../src/utils/grpc");
 const GeneralUtils = require("../src/utils/general");
+const uuidv4 = require("uuid").v4;
 
 if (args.logLevel) {
   logger.level = args.logLevel;
@@ -178,17 +179,25 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
     }
   }
 
+  const requestReadableID = GeneralUtils.loggerIdFromRequest(call, serviceMethodName);
+  const requestUUID = uuidv4();
+  const callContext = {
+    logger: logger.child({
+      method: serviceMethodName,
+      requestId: requestReadableID,
+      uuid: requestUUID,
+    }),
+  };
   try {
-    logger.info(
-      "new request - driver: %s method: %s call: %j",
+    callContext.logger.info(
+      "new request: driver: %s, call: %j",
       driver.constructor.name,
-      serviceMethodName,
       cleansedCall
     );
 
     const lockKeys = GeneralUtils.lockKeysFromRequest(call, serviceMethodName);
     if (lockKeys.length > 0) {
-      logger.debug("operation lock keys: %j", lockKeys);
+      callContext.logger.debug("operation lock keys: %j", lockKeys);
       // check locks
       lockKeys.forEach((key) => {
         if (operationLock.has(key)) {
@@ -216,7 +225,7 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
     let response;
     let responseError;
     try {
-      // aquire locks
+      // acquire locks
       if (lockKeys.length > 0) {
         lockKeys.forEach((key) => {
           operationLock.add(key);
@@ -246,10 +255,8 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
       );
     }
 
-    logger.info(
-      "new response - driver: %s method: %s response: %j",
-      driver.constructor.name,
-      serviceMethodName,
+    callContext.logger.info(
+      "new response: %j",
       response
     );
 
@@ -265,10 +272,8 @@ async function requestHandlerProxy(call, callback, serviceMethodName) {
       message = stringify(e);
     }
 
-    logger.error(
-      "handler error - driver: %s method: %s error: %s",
-      driver.constructor.name,
-      serviceMethodName,
+    callContext.logger.error(
+      "handler error: %s",
       message
     );
 

--- a/src/driver/controller-client-common/index.js
+++ b/src/driver/controller-client-common/index.js
@@ -548,7 +548,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(callContext, call) {
     const driver = this;
 
     const config_key = driver.getConfigKey();
@@ -840,7 +840,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(callContext, call) {
     const driver = this;
 
     const volume_id = call.request.volume_id;
@@ -873,7 +873,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -885,7 +885,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     const driver = this;
 
     if (
@@ -925,7 +925,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -936,7 +936,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -963,7 +963,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(callContext, call) {
     const driver = this;
 
     const config_key = driver.getConfigKey();
@@ -1305,7 +1305,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(callContext, call) {
     const driver = this;
 
     let snapshot_id = call.request.snapshot_id;
@@ -1393,7 +1393,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
 
     const volume_id = call.request.volume_id;

--- a/src/driver/controller-client-common/index.js
+++ b/src/driver/controller-client-common/index.js
@@ -156,7 +156,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(callContext, capabilities) {
     const driver = this;
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
 
@@ -560,7 +560,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -902,7 +902,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -1414,7 +1414,7 @@ class ControllerClientCommonDriver extends CsiBaseDriver {
       );
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/controller-local-hostpath/index.js
+++ b/src/driver/controller-local-hostpath/index.js
@@ -78,7 +78,7 @@ class ControllerLocalHostpathDriver extends ControllerClientCommonDriver {
    * @param {*} call
    * @returns
    */
-  async NodeGetInfo(call) {
+  async NodeGetInfo(callContext, call) {
     const response = await super.NodeGetInfo(...arguments);
     response.accessible_topology = {
       segments: {

--- a/src/driver/controller-objectivefs/index.js
+++ b/src/driver/controller-objectivefs/index.js
@@ -270,7 +270,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(callContext, call) {
     const driver = this;
     const pool = _.get(driver.options, "objectivefs.pool");
     const object_store = _.get(driver.options, "objectivefs.env.OBJECTSTORE");
@@ -301,7 +301,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(callContext, call) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");
@@ -446,7 +446,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(callContext, call) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");
@@ -481,7 +481,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -493,7 +493,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -506,7 +506,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(callContext, call) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");
@@ -588,7 +588,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -599,7 +599,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -612,7 +612,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -623,7 +623,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
     const ofsClient = await driver.getObjectiveFSClient();
     const pool = _.get(driver.options, "objectivefs.pool");

--- a/src/driver/controller-objectivefs/index.js
+++ b/src/driver/controller-objectivefs/index.js
@@ -159,7 +159,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
     return ["fuse.objectivefs", "objectivefs"];
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(callContext, capabilities) {
     const driver = this;
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
 
@@ -347,7 +347,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -651,7 +651,7 @@ class ControllerObjectiveFSDriver extends CsiBaseDriver {
       throw new GrpcError(grpc.status.INVALID_ARGUMENT, `missing capabilities`);
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/controller-synology/index.js
+++ b/src/driver/controller-synology/index.js
@@ -319,7 +319,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(callContext, call) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -677,7 +677,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(callContext, call) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -785,7 +785,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(callContext, call) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -877,7 +877,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
     const location = driver.getLocation();
@@ -907,7 +907,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -918,7 +918,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -929,7 +929,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(callContext, call) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 
@@ -1049,7 +1049,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(callContext, call) {
     // throw new GrpcError(
     //   grpc.status.UNIMPLEMENTED,
     //   `operation not supported by driver`
@@ -1100,7 +1100,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
     const httpClient = await driver.getHttpClient();
 

--- a/src/driver/controller-synology/index.js
+++ b/src/driver/controller-synology/index.js
@@ -250,7 +250,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(callContext, capabilities) {
     const driverResourceType = this.getDriverResourceType();
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
 
@@ -330,7 +330,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -890,7 +890,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -1150,7 +1150,7 @@ class ControllerSynologyDriver extends CsiBaseDriver {
         break;
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
     if (result.valid !== true) {
       return { message: result.message };
     }

--- a/src/driver/controller-zfs-local/index.js
+++ b/src/driver/controller-zfs-local/index.js
@@ -227,7 +227,7 @@ class ControllerZfsLocalDriver extends ControllerZfsBaseDriver {
    * @param {*} call
    * @returns
    */
-  async NodeGetInfo(call) {
+  async NodeGetInfo(callContext, call) {
     const response = await super.NodeGetInfo(...arguments);
     response.accessible_topology = {
       segments: {

--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -562,7 +562,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(callContext, call) {
     const driver = this;
 
     if (driver.ctx.args.csiMode.includes("controller")) {
@@ -634,7 +634,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const execClient = this.getExecClient();
@@ -1269,7 +1269,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(callContext, call) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -1401,7 +1401,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -1520,7 +1520,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -1569,7 +1569,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerGetVolume(call) {
+  async ControllerGetVolume(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -1650,7 +1650,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -1790,7 +1790,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -2044,7 +2044,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const zb = await this.getZetabyte();
@@ -2352,7 +2352,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(callContext, call) {
     const driver = this;
     const zb = await this.getZetabyte();
 
@@ -2423,7 +2423,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
     const zb = await this.getZetabyte();
 

--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -250,7 +250,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(callContext, capabilities) {
     const driverZfsResourceType = this.getDriverZfsResourceType();
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
 
@@ -658,7 +658,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -1534,7 +1534,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -2461,7 +2461,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       }
     }
 
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -2082,7 +2082,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     return access_modes;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(callContext, capabilities) {
     const driverZfsResourceType = this.getDriverZfsResourceType();
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
 
@@ -2254,7 +2254,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       call.request.volume_capabilities &&
       call.request.volume_capabilities.length > 0
     ) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
       }
@@ -3269,7 +3269,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -4450,7 +4450,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       }
     }
 
-    const result = this.assertCapabilities(capabilities);
+    const result = this.assertCapabilities(callContext, capabilities);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -2177,7 +2177,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(callContext, call) {
     const driver = this;
     const httpApiClient = await driver.getTrueNASHttpApiClient();
 
@@ -2228,7 +2228,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -3000,7 +3000,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(callContext, call) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
@@ -3133,7 +3133,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -3254,7 +3254,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
@@ -3302,7 +3302,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerGetVolume(call) {
+  async ControllerGetVolume(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpApiClient = await this.getTrueNASHttpApiClient();
@@ -3376,7 +3376,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpClient = await this.getHttpClient();
@@ -3518,7 +3518,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpClient = await this.getHttpClient();
@@ -3935,7 +3935,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(callContext, call) {
     const driver = this;
     const driverZfsResourceType = this.getDriverZfsResourceType();
     const httpClient = await this.getHttpClient();
@@ -4333,7 +4333,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(callContext, call) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
@@ -4413,7 +4413,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
     const httpApiClient = await this.getTrueNASHttpApiClient();
 

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -35,7 +35,7 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
    *
    * @param {*} call
    */
-  async Probe(call) {
+  async Probe(callContext, call) {
     const driver = this;
 
     if (driver.ctx.args.csiMode.includes("controller")) {

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -767,7 +767,7 @@ class CsiBaseDriver {
     }
 
     if (call.request.volume_context.provisioner_driver == "node-manual") {
-      result = await this.assertCapabilities([capability], node_attach_driver);
+      result = await this.assertCapabilities(callContext, [capability], node_attach_driver);
       if (!result.valid) {
         throw new GrpcError(
           grpc.status.INVALID_ARGUMENT,
@@ -775,7 +775,7 @@ class CsiBaseDriver {
         );
       }
     } else {
-      result = await this.assertCapabilities([capability]);
+      result = await this.assertCapabilities(callContext, [capability]);
       if (!result.valid) {
         throw new GrpcError(
           grpc.status.INVALID_ARGUMENT,

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -497,14 +497,14 @@ class CsiBaseDriver {
     return volume_id;
   }
 
-  async GetPluginInfo(call) {
+  async GetPluginInfo(callContext, call) {
     return {
       name: this.ctx.args.csiName,
       vendor_version: this.ctx.args.version,
     };
   }
 
-  async GetPluginCapabilities(call) {
+  async GetPluginCapabilities(callContext, call) {
     let capabilities;
     const response = {
       capabilities: [],
@@ -589,11 +589,11 @@ class CsiBaseDriver {
     return response;
   }
 
-  async Probe(call) {
+  async Probe(callContext, call) {
     return { ready: { value: true } };
   }
 
-  async ControllerGetCapabilities(call) {
+  async ControllerGetCapabilities(callContext, call) {
     let capabilities;
     const response = {
       capabilities: [],
@@ -636,7 +636,7 @@ class CsiBaseDriver {
     return response;
   }
 
-  async NodeGetCapabilities(call) {
+  async NodeGetCapabilities(callContext, call) {
     let capabilities;
     const response = {
       capabilities: [],
@@ -661,7 +661,7 @@ class CsiBaseDriver {
     return response;
   }
 
-  async NodeGetInfo(call) {
+  async NodeGetInfo(callContext, call) {
     return {
       node_id: process.env.CSI_NODE_ID || os.hostname(),
       max_volumes_per_node: 0,
@@ -678,7 +678,7 @@ class CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodeStageVolume(call) {
+  async NodeStageVolume(callContext, call) {
     const driver = this;
     const mount = driver.getDefaultMountInstance();
     const filesystem = driver.getDefaultFilesystemInstance();
@@ -2437,7 +2437,7 @@ class CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodeUnstageVolume(call) {
+  async NodeUnstageVolume(callContext, call) {
     const driver = this;
     const mount = driver.getDefaultMountInstance();
     const filesystem = driver.getDefaultFilesystemInstance();
@@ -2969,7 +2969,7 @@ class CsiBaseDriver {
     return {};
   }
 
-  async NodePublishVolume(call) {
+  async NodePublishVolume(callContext, call) {
     const driver = this;
     const mount = driver.getDefaultMountInstance();
     const filesystem = driver.getDefaultFilesystemInstance();
@@ -3290,7 +3290,7 @@ class CsiBaseDriver {
     }
   }
 
-  async NodeUnpublishVolume(call) {
+  async NodeUnpublishVolume(callContext, call) {
     const driver = this;
     const mount = driver.getDefaultMountInstance();
     const filesystem = driver.getDefaultFilesystemInstance();
@@ -3458,7 +3458,7 @@ class CsiBaseDriver {
     return {};
   }
 
-  async NodeGetVolumeStats(call) {
+  async NodeGetVolumeStats(callContext, call) {
     const driver = this;
     const mount = driver.getDefaultMountInstance();
     const filesystem = driver.getDefaultFilesystemInstance();
@@ -3692,7 +3692,7 @@ class CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodeExpandVolume(call) {
+  async NodeExpandVolume(callContext, call) {
     const driver = this;
     const mount = driver.getDefaultMountInstance();
     const filesystem = driver.getDefaultFilesystemInstance();

--- a/src/driver/node-manual/index.js
+++ b/src/driver/node-manual/index.js
@@ -242,7 +242,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateVolume(call) {
+  async CreateVolume(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -253,7 +253,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteVolume(call) {
+  async DeleteVolume(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -264,7 +264,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ControllerExpandVolume(call) {
+  async ControllerExpandVolume(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -275,7 +275,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -286,7 +286,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListVolumes(call) {
+  async ListVolumes(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -297,7 +297,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ListSnapshots(call) {
+  async ListSnapshots(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -308,7 +308,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async CreateSnapshot(call) {
+  async CreateSnapshot(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -319,7 +319,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async DeleteSnapshot(call) {
+  async DeleteSnapshot(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`
@@ -330,7 +330,7 @@ class NodeManualDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     throw new GrpcError(
       grpc.status.UNIMPLEMENTED,
       `operation not supported by driver`

--- a/src/driver/node-manual/index.js
+++ b/src/driver/node-manual/index.js
@@ -100,7 +100,7 @@ class NodeManualDriver extends CsiBaseDriver {
     }
   }
 
-  assertCapabilities(capabilities, node_attach_driver) {
+  assertCapabilities(callContext, capabilities, node_attach_driver) {
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
 
     let message = null;

--- a/src/driver/zfs-local-ephemeral-inline/index.js
+++ b/src/driver/zfs-local-ephemeral-inline/index.js
@@ -272,7 +272,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodePublishVolume(call) {
+  async NodePublishVolume(callContext, call) {
     const driver = this;
     const zb = this.getZetabyte();
 
@@ -386,7 +386,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async NodeUnpublishVolume(call) {
+  async NodeUnpublishVolume(callContext, call) {
     const zb = this.getZetabyte();
     const filesystem = new Filesystem();
     let result;
@@ -454,7 +454,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async GetCapacity(call) {
+  async GetCapacity(callContext, call) {
     const driver = this;
     const zb = this.getZetabyte();
 
@@ -488,7 +488,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    *
    * @param {*} call
    */
-  async ValidateVolumeCapabilities(call) {
+  async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
     const result = this.assertCapabilities(call.request.volume_capabilities);
 

--- a/src/driver/zfs-local-ephemeral-inline/index.js
+++ b/src/driver/zfs-local-ephemeral-inline/index.js
@@ -165,7 +165,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     return datasetParentName;
   }
 
-  assertCapabilities(capabilities) {
+  assertCapabilities(callContext, capabilities) {
     // hard code this for now
     const driverZfsResourceType = "filesystem";
     this.ctx.logger.verbose("validating capabilities: %j", capabilities);
@@ -309,7 +309,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     }
 
     if (capability) {
-      const result = this.assertCapabilities([capability]);
+      const result = this.assertCapabilities(callContext, [capability]);
 
       if (result.valid !== true) {
         throw new GrpcError(grpc.status.INVALID_ARGUMENT, result.message);
@@ -468,7 +468,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
     }
 
     if (call.request.volume_capabilities) {
-      const result = this.assertCapabilities(call.request.volume_capabilities);
+      const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
       if (result.valid !== true) {
         return { available_capacity: 0 };
@@ -490,7 +490,7 @@ class ZfsLocalEphemeralInlineDriver extends CsiBaseDriver {
    */
   async ValidateVolumeCapabilities(callContext, call) {
     const driver = this;
-    const result = this.assertCapabilities(call.request.volume_capabilities);
+    const result = this.assertCapabilities(callContext, call.request.volume_capabilities);
 
     if (result.valid !== true) {
       return { message: result.message };

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -92,6 +92,49 @@ function lockKeysFromRequest(call, serviceMethodName) {
   }
 }
 
+function loggerIdFromRequest(call, serviceMethodName) {
+  switch (serviceMethodName) {
+    // controller
+    case "CreateVolume":
+      return call.request.name;
+    case "DeleteVolume":
+    case "ControllerExpandVolume":
+    case "ControllerPublishVolume":
+    case "ControllerUnpublishVolume":
+    case "ValidateVolumeCapabilities":
+    case "ControllerGetVolume":
+    case "ControllerModifyVolume":
+      return call.request.volume_id;
+    case "CreateSnapshot":
+      return call.request.source_volume_id;
+    case "DeleteSnapshot":
+      return call.request.snapshot_id;
+    case "ListVolumes":
+    case "GetCapacity":
+    case "ControllerGetCapabilities":
+    case "ListSnapshots":
+      return '';
+
+    // node
+    case "NodeStageVolume":
+    case "NodeUnstageVolume":
+    case "NodePublishVolume":
+    case "NodeUnpublishVolume":
+    case "NodeGetVolumeStats":
+    case "NodeExpandVolume":
+      return call.request.volume_id;
+
+    case "NodeGetCapabilities":
+    case "NodeGetInfo":
+    case "GetPluginInfo":
+    case "GetPluginCapabilities":
+    case "Probe":
+      return '';
+    default:
+      throw `loggerIdFromRequest: unknown method: ${serviceMethodName}`;
+  }
+}
+
 function getLargestNumber() {
   let number;
   for (let i = 0; i < arguments.length; i++) {
@@ -278,6 +321,7 @@ module.exports.crc32 = crc32;
 module.exports.crc16 = crc16;
 module.exports.crc8 = crc8;
 module.exports.lockKeysFromRequest = lockKeysFromRequest;
+module.exports.loggerIdFromRequest = loggerIdFromRequest;
 module.exports.getLargestNumber = getLargestNumber;
 module.exports.stringify = stringify;
 module.exports.before_string = before_string;


### PR DESCRIPTION
This PR is a part of this issue:
- https://github.com/democratic-csi/democratic-csi/pull/467

This PR adds `callContext` argument to each CSI method.
This allow the app to customize method behavior for each call.
Particularly, context contains a separate logger that has unique fields for each call.

This is supposed to be a simple change to make review process easier.
Only interface is changed, custom logger is not actually used anywhere yet.