### PR TITLE
fix: support TrueNAS Community edition in platform check

### DIFF
--- a/src/driver/freenas/http/api.js
+++ b/src/driver/freenas/http/api.js
@@ -162,11 +162,20 @@ class Api {
 
   async getIsScale() {
     const systemVersion = await this.getSystemVersion();
-
-    if (systemVersion.v2 && systemVersion.v2.toLowerCase().includes("scale")) {
+    const versionRaw = systemVersion.v2?.toLowerCase() || "";
+  
+    if (versionRaw.includes("scale")) {
       return true;
     }
-
+  
+    const match = versionRaw.match(/^truenas-(\d+)\.(\d+)/);
+    if (match) {
+      const major = parseInt(match[1], 10);
+      if (major >= 22) {
+        return true;
+      }
+    }
+  
     return false;
   }
 

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -2166,11 +2166,15 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
   async getIsScale() {
     const systemVersion = await this.getSystemVersion();
-
-    if (systemVersion.v2 && systemVersion.v2.toLowerCase().includes("scale")) {
+  
+    if (
+      systemVersion.v2 &&
+      (systemVersion.v2.toLowerCase().includes("scale") ||
+       systemVersion.v2.toLowerCase().includes("community"))
+    ) {
       return true;
     }
-
+  
     return false;
   }
 

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -2166,15 +2166,20 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
 
   async getIsScale() {
     const systemVersion = await this.getSystemVersion();
-  
-    if (
-      systemVersion.v2 &&
-      (systemVersion.v2.toLowerCase().includes("scale") ||
-       systemVersion.v2.toLowerCase().includes("community"))
-    ) {
+    const versionRaw = systemVersion.v2?.toLowerCase() || "";
+
+    if (versionRaw.includes("scale")) {
       return true;
     }
-  
+
+    const match = versionRaw.match(/^truenas-(\d+)\.(\d+)/);
+    if (match) {
+      const major = parseInt(match[1], 10);
+      if (major >= 22) {
+        return true;
+      }
+    }
+
     return false;
   }
 


### PR DESCRIPTION
This PR updates the platform check to support TrueNAS Community (25.04+), which replaces SCALE but remains fully compatible.

🔧 What changed
The getIsScale() function now also returns true when the system version includes "Community".

❗ Not yet tested
I have not yet verified this change in a running cluster. Opening the PR to gather feedback and possibly assist others facing [Issue #475](https://github.com/democratic-csi/democratic-csi/issues/475).

🐛 Related Issue
Closes #475