### PR TITLE
feat(ssh/zfs): update path resolution logic for scale

### DIFF
--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -39,18 +39,24 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
       }
       options.idempotent = true;
 
+      options.sudo = _.get(this.options, "zfs.cli.sudoEnabled", false);
+
+      // Run automatic detection first
+      if (typeof this.setZetabyteCustomOptions === "function") {
+        await this.setZetabyteCustomOptions(options);
+      }
+
+      // Manual override comes after automatic detection
+      // Only apply if user explicitly provided non-empty paths
       if (
         this.options.zfs.hasOwnProperty("cli") &&
         this.options.zfs.cli &&
-        this.options.zfs.cli.hasOwnProperty("paths")
+        this.options.zfs.cli.hasOwnProperty("paths") &&
+        this.options.zfs.cli.paths &&
+        Object.keys(this.options.zfs.cli.paths).length > 0
       ) {
+        // User explicitly configured paths - use them
         options.paths = this.options.zfs.cli.paths;
-      }
-
-      options.sudo = _.get(this.options, "zfs.cli.sudoEnabled", false);
-
-      if (typeof this.setZetabyteCustomOptions === "function") {
-        await this.setZetabyteCustomOptions(options);
       }
 
       return new Zetabyte(options);

--- a/src/driver/freenas/ssh.js
+++ b/src/driver/freenas/ssh.js
@@ -71,18 +71,24 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
       options.executor = new ZfsSshProcessManager(sshClient);
       options.idempotent = true;
 
+      options.sudo = _.get(this.options, "zfs.cli.sudoEnabled", false);
+
+      // Run automatic detection first
+      if (typeof this.setZetabyteCustomOptions === "function") {
+        await this.setZetabyteCustomOptions(options);
+      }
+
+      // Manual override comes after automatic detection
+      // Only apply if user explicitly provided non-empty paths
       if (
         this.options.zfs.hasOwnProperty("cli") &&
         this.options.zfs.cli &&
-        this.options.zfs.cli.hasOwnProperty("paths")
+        this.options.zfs.cli.hasOwnProperty("paths") &&
+        this.options.zfs.cli.paths &&
+        Object.keys(this.options.zfs.cli.paths).length > 0
       ) {
+        // User explicitly configured paths - use them
         options.paths = this.options.zfs.cli.paths;
-      }
-
-      options.sudo = _.get(this.options, "zfs.cli.sudoEnabled", false);
-
-      if (typeof this.setZetabyteCustomOptions === "function") {
-        await this.setZetabyteCustomOptions(options);
       }
 
       return new Zetabyte(options);
@@ -112,22 +118,33 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
     if (!options.hasOwnProperty("paths")) {
       const majorMinor = await this.getSystemVersionMajorMinor();
       const isScale = await this.getIsScale();
+      
       if (!isScale && Number(majorMinor) >= 12) {
+        // TrueNAS CORE/Enterprise version 12+
         options.paths = {
           zfs: "/usr/local/sbin/zfs",
           zpool: "/usr/local/sbin/zpool",
           sudo: "/usr/local/bin/sudo",
           chroot: "/usr/sbin/chroot",
         };
-      }
-
-      if (isScale && Number(majorMinor) >= 25) {
-        options.paths = {
-          zfs: "/usr/sbin/zfs",
-          zpool: "/usr/sbin/zpool",
-          sudo: "/usr/bin/sudo",
-          chroot: "/usr/sbin/chroot",
-        };
+      } else if (isScale) {
+        if (Number(majorMinor) >= 25) {
+          // TrueNAS SCALE version 25+ (paths changed to /usr/sbin in 25.04)
+          options.paths = {
+            zfs: "/usr/sbin/zfs",
+            zpool: "/usr/sbin/zpool",
+            sudo: "/usr/bin/sudo",
+            chroot: "/usr/sbin/chroot",
+          };
+        } else {
+          // TrueNAS SCALE versions before 25
+          options.paths = {
+            zfs: "/usr/local/sbin/zfs",
+            zpool: "/usr/local/sbin/zpool",
+            sudo: "/usr/bin/sudo",
+            chroot: "/usr/sbin/chroot",
+          };
+        }
       }
     }
   }
@@ -2179,8 +2196,19 @@ class FreeNASSshDriver extends ControllerZfsBaseDriver {
   async getIsScale() {
     const systemVersion = await this.getSystemVersion();
 
-    if (systemVersion.v2 && systemVersion.v2.toLowerCase().includes("scale")) {
-      return true;
+    if (systemVersion.v2) {
+      const versionLower = systemVersion.v2.toLowerCase();
+      // Check for explicit "scale" in version string
+      if (versionLower.includes("scale")) {
+        return true;
+      }
+      // TrueNAS 25+ doesn't include "SCALE" in version string, but versions 25+ are SCALE-only
+      if (versionLower.includes("truenas")) {
+        const majorVersion = await this.getSystemVersionMajor();
+        if (Number(majorVersion) >= 25) {
+          return true;
+        }
+      }
     }
 
     return false;


### PR DESCRIPTION
TrueNAS SCALE 25.04+ moved ZFS binaries from `/usr/local/sbin/` to `/usr/sbin/`, breaking democratic-csi with `bash: line 1: /usr/local/sbin/zfs: No such file or directory`. 

There was already a fix for this in commit edfdf86 that added automatic path detection:

```javascript
if (isScale && Number(majorMinor) >= 25) {
  options.paths = {
    zfs: "/usr/sbin/zfs", 
    zpool: "/usr/sbin/zpool",
    // ...
  };
}
```

But it wasn't because of an execution order bug. The problem was in `getZetabyte()` where manual path override checking happened *before* automatic detection:

```javascript
// This runs FIRST and sets options.paths = undefined
if (this.options.zfs.cli?.hasOwnProperty("paths")) {
  options.paths = this.options.zfs.cli.paths;  
}

// This runs AFTER (too late!)
if (typeof this.setZetabyteCustomOptions === "function") {
  await this.setZetabyteCustomOptions(options);
}
```

When users set `zfs.cli.sudoEnabled: true` in Helm, YAML parsing creates `paths: undefined`, so `hasOwnProperty("paths")` returns true even though they never set paths. This triggered the override logic and skipped automatic detection.

Users in #487 were confused why the "automatic" fix still required manual configuration:

> "didn't pick up the new defaults for me"
> "tested without defining paths again but didn't work"

**The fix:** Switch the execution order so automatic detection runs first, then manual overrides (with better validation):

```javascript
// Automatic detection runs FIRST
if (typeof this.setZetabyteCustomOptions === "function") {
  await this.setZetabyteCustomOptions(options);
}

// Manual override only when paths are actually provided
if (this.options.zfs.cli?.paths && Object.keys(this.options.zfs.cli.paths).length > 0) {
  options.paths = this.options.zfs.cli.paths;
}
```

Now TrueNAS SCALE 25.04+ users get automatic path detection without any config changes, while existing manual configurations still work.

Fixes #487