### PR TITLE
Allowing ZFS datasetParentName to be defined in the k8s storageclass

### DIFF
--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -172,14 +172,31 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     return zb.options.paths.sudo || "/usr/bin/sudo";
   }
 
-  getDatasetParentName() {
-    let datasetParentName = this.options.zfs.datasetParentName;
+  getDatasetParentName(call = null) {
+    let datasetParentName;
+    
+    // First check if datasetParentName is provided in storage class parameters
+    if (call && call.request && call.request.parameters) {
+      const paramDatasetParentName = this.getNormalizedParameterValue(
+        call.request.parameters,
+        "datasetParentName"
+      );
+      if (paramDatasetParentName) {
+        datasetParentName = paramDatasetParentName;
+      }
+    }
+    
+    // Fallback to configuration option
+    if (!datasetParentName) {
+      datasetParentName = this.options.zfs.datasetParentName;
+    }
+    
     datasetParentName = datasetParentName.replace(/\/$/, "");
     return datasetParentName;
   }
 
-  getVolumeParentDatasetName() {
-    let datasetParentName = this.getDatasetParentName();
+  getVolumeParentDatasetName(call = null) {
+    let datasetParentName = this.getDatasetParentName(call);
     //datasetParentName += "/v";
     datasetParentName = datasetParentName.replace(/\/$/, "");
     return datasetParentName;
@@ -700,7 +717,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
       pvcOptions,
     ]);
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let snapshotParentDatasetName = this.getDetachedSnapshotParentDatasetName();
     let zvolBlocksize = driverOptions.zfs.zvolBlocksize || "16K";
     let name = call.request.name;
@@ -1344,7 +1361,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     const zb = await this.getZetabyte();
     const driverOptions = driver.getMergedDriverOptions([]);
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let name = call.request.volume_id;
 
     if (!datasetParentName) {
@@ -1514,7 +1531,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     const zb = await this.getZetabyte();
     const driverOptions = driver.getMergedDriverOptions([]);
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let name = call.request.volume_id;
 
     if (!datasetParentName) {
@@ -1684,7 +1701,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     const zb = await this.getZetabyte();
     const driverOptions = driver.getMergedDriverOptions([]);
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let response;
     let name = call.request.volume_id;
 
@@ -1766,7 +1783,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     const zb = await this.getZetabyte();
     const driverOptions = driver.getMergedDriverOptions([]);
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let entries = [];
     let entries_length = 0;
     let next_token;
@@ -2190,7 +2207,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
         types.push("volume");
       }
     } else {
-      datasetParentName = this.getVolumeParentDatasetName();
+      datasetParentName = this.getVolumeParentDatasetName(call);
       types.push("snapshot");
     }
 

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -2393,14 +2393,31 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
   }
 
-  getDatasetParentName() {
-    let datasetParentName = this.options.zfs.datasetParentName;
+  getDatasetParentName(call = null) {
+    let datasetParentName;
+    
+    // First check if datasetParentName is provided in storage class parameters
+    if (call && call.request && call.request.parameters) {
+      const paramDatasetParentName = this.getNormalizedParameterValue(
+        call.request.parameters,
+        "datasetParentName"
+      );
+      if (paramDatasetParentName) {
+        datasetParentName = paramDatasetParentName;
+      }
+    }
+    
+    // Fallback to configuration option
+    if (!datasetParentName) {
+      datasetParentName = this.options.zfs.datasetParentName;
+    }
+    
     datasetParentName = datasetParentName.replace(/\/$/, "");
     return datasetParentName;
   }
 
-  getVolumeParentDatasetName() {
-    let datasetParentName = this.getDatasetParentName();
+  getVolumeParentDatasetName(call = null) {
+    let datasetParentName = this.getDatasetParentName(call);
     //datasetParentName += "/v";
     datasetParentName = datasetParentName.replace(/\/$/, "");
     return datasetParentName;
@@ -2636,7 +2653,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let snapshotParentDatasetName = this.getDetachedSnapshotParentDatasetName();
     let zvolBlocksize = this.options.zfs.zvolBlocksize || "16K";
     let name = call.request.name;
@@ -3407,7 +3424,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let name = call.request.volume_id;
 
     if (!datasetParentName) {
@@ -3707,7 +3724,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
 
     if (!datasetParentName) {
       throw new GrpcError(
@@ -3756,7 +3773,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let response;
     let name = call.request.volume_id;
 
@@ -3831,7 +3848,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let entries = [];
     let entries_length = 0;
     let next_token;
@@ -4904,7 +4921,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
       throw new GrpcError(grpc.status.INVALID_ARGUMENT, `missing capabilities`);
     }
 
-    let datasetParentName = this.getVolumeParentDatasetName();
+    let datasetParentName = this.getVolumeParentDatasetName(call);
     let name = volume_id;
 
     if (!datasetParentName) {


### PR DESCRIPTION
Allow to override datasetParentName in the StorageClass definition. This way you can define storage classes backed by different mediums or for different reasons. 

```
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: nvme-zfs
parameters:
  datasetParentName: nvme/pvc
  fsType: ext4
provisioner: org.democratic-csi.iscsi
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

To test this out yourself, you can overwrite the images in the helm chart with 
```
image:
  registry: mandusm/democratic-csi
  tag: next
```