### PR TITLE
fix(docs): update talos docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ node:
         value: nsenter
       - name: ISCSIADM_HOST_PATH
         value: /usr/local/sbin/iscsiadm
-    iscsiDirHostPath: /usr/local/etc/iscsi
+    iscsiDirHostPath: /var/iscsi
     iscsiDirHostPathType: ""
 ```
 


### PR DESCRIPTION
In modern versions of talos, only /var/ is writable