### PR TITLE
fix(freenas-api-nfs): handle 405 errors in ControllerExpandVolume

### DIFF
--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -3682,16 +3682,54 @@ class FreeNASApiDriver extends CsiBaseDriver {
     }
 
     if (setProps) {
-      await httpApiClient.DatasetSet(datasetName, properties);
+      try {
+        await httpApiClient.DatasetSet(datasetName, properties);
+      } catch (err) {
+        // Check if error is a 405 Not Allowed (common TrueNAS API issue)
+        const errorMessage = err.message || err.toString();
+        if (errorMessage.includes("405") || errorMessage.includes("Not Allowed")) {
+          throw new GrpcError(
+            grpc.status.INTERNAL,
+            `Failed to expand volume: TrueNAS API returned 405 Not Allowed. This may be a TrueNAS API issue. Error: ${errorMessage}`
+          );
+        }
+        // Re-throw other errors with proper context
+        throw new GrpcError(
+          grpc.status.INTERNAL,
+          `Failed to expand volume: ${errorMessage}`
+        );
+      }
     }
 
     await this.expandVolume(call, datasetName);
+
+    // Get actual capacity from dataset to return accurate value
+    let actualCapacityBytes = capacity_bytes;
+    try {
+      const currentProps = await httpApiClient.DatasetGet(datasetName, [
+        driverZfsResourceType == "volume" ? "volsize" : "refquota",
+      ]);
+      if (currentProps) {
+        const capacityProp = driverZfsResourceType == "volume" 
+          ? currentProps.volsize 
+          : currentProps.refquota;
+        if (capacityProp && capacityProp.rawvalue) {
+          actualCapacityBytes = Number(capacityProp.rawvalue);
+        }
+      }
+    } catch (err) {
+      // If we can't get actual capacity, use requested capacity
+      // This is not ideal but better than returning 0
+      driver.ctx.logger.warn(
+        `Could not retrieve actual capacity for ${datasetName}, using requested capacity: ${err.message}`
+      );
+    }
 
     return {
       capacity_bytes:
         this.options.zfs.datasetEnableQuotas ||
         driverZfsResourceType == "volume"
-          ? capacity_bytes
+          ? actualCapacityBytes
           : 0,
       node_expansion_required: driverZfsResourceType == "volume" ? true : false,
     };

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -3687,7 +3687,13 @@ class FreeNASApiDriver extends CsiBaseDriver {
       } catch (err) {
         // Check if error is a 405 Not Allowed (common TrueNAS API issue)
         const errorMessage = err.message || err.toString();
-        if (errorMessage.includes("405") || errorMessage.includes("Not Allowed")) {
+        const statusCode = err && (err.statusCode || err.status || err.code);
+        const is405Status =
+          statusCode === 405 ||
+          (typeof statusCode === "string" && statusCode.trim() === "405");
+        const messageIndicates405 =
+          /\b405\b/.test(errorMessage) || /\bNot\s+Allowed\b/i.test(errorMessage);
+        if (is405Status || messageIndicates405) {
           throw new GrpcError(
             grpc.status.INTERNAL,
             `Failed to expand volume: TrueNAS API returned 405 Not Allowed. This may be a TrueNAS API issue. Error: ${errorMessage}`

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -3705,24 +3705,27 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
     // Get actual capacity from dataset to return accurate value
     let actualCapacityBytes = capacity_bytes;
-    try {
-      const currentProps = await httpApiClient.DatasetGet(datasetName, [
-        driverZfsResourceType == "volume" ? "volsize" : "refquota",
-      ]);
-      if (currentProps) {
-        const capacityProp = driverZfsResourceType == "volume" 
-          ? currentProps.volsize 
-          : currentProps.refquota;
-        if (capacityProp && capacityProp.rawvalue) {
-          actualCapacityBytes = Number(capacityProp.rawvalue);
+    // Only retrieve actual capacity when it can affect the returned value
+    if (this.options.zfs.datasetEnableQuotas || driverZfsResourceType == "volume") {
+      try {
+        const currentProps = await httpApiClient.DatasetGet(datasetName, [
+          driverZfsResourceType == "volume" ? "volsize" : "refquota",
+        ]);
+        if (currentProps) {
+          const capacityProp = driverZfsResourceType == "volume"
+            ? currentProps.volsize
+            : currentProps.refquota;
+          if (capacityProp && capacityProp.rawvalue) {
+            actualCapacityBytes = Number(capacityProp.rawvalue);
+          }
         }
+      } catch (err) {
+        // If we can't get actual capacity, use requested capacity
+        // This is not ideal but better than returning 0
+        driver.ctx.logger.warn(
+          `Could not retrieve actual capacity for ${datasetName}, using requested capacity: ${err.message}`
+        );
       }
-    } catch (err) {
-      // If we can't get actual capacity, use requested capacity
-      // This is not ideal but better than returning 0
-      driver.ctx.logger.warn(
-        `Could not retrieve actual capacity for ${datasetName}, using requested capacity: ${err.message}`
-      );
     }
 
     return {


### PR DESCRIPTION
# Fix: Handle 405 errors in ControllerExpandVolume for freenas-api-nfs

## Problem

Volume expansion fails when TrueNAS API returns 405 Not Allowed. The driver currently:
1. Calls `DatasetSet` which throws an error on 405
2. The error is not properly caught/handled
3. The function continues and returns `capacity_bytes: 0`
4. Kubernetes external resizer tries to update PV to 0, which is rejected as invalid
5. PVCs get stuck in "Resizing" state with "capacity to 0" errors

This is related to issue #394.

## Root Cause

The `DatasetSet` call in `ControllerExpandVolume` is not wrapped in error handling. When TrueNAS API returns 405 (or any error), the error should be caught and converted to a proper gRPC error, but instead the function may continue execution and return invalid values.

Additionally, the function returns the requested capacity instead of the actual capacity from the dataset, which can lead to inconsistencies.

## Solution

1. **Wrap `DatasetSet` in try-catch**: Properly catch API errors and convert them to gRPC errors
2. **Detect 405 errors specifically**: Provide a clear error message for the common 405 case
3. **Get actual capacity**: Query the dataset after expansion to return the actual capacity instead of requested
4. **Better error messages**: Include the original error message for debugging

## Changes

- Added try-catch around `DatasetSet` call
- Added specific handling for 405 errors with descriptive message
- Added code to retrieve actual capacity from dataset after expansion
- Fallback to requested capacity if actual capacity cannot be retrieved (with warning)

## Testing

This fix should be tested with:
- TrueNAS systems that return 405 errors
- Normal expansion scenarios
- Both filesystem and volume types
- Cases where quota is enabled and disabled

## Related Issues

Fixes #394

## Notes

Some users in issue #394 reported that enabling debug logging makes expansion work. This suggests there may be a timing or initialization issue with the TrueNAS API. This fix ensures that if the API call fails, we get a proper error instead of silently returning 0, which will help diagnose the underlying issue.
