### PR TITLE
[docs] Update `iscsiDirHostPath` for iscsi-tools v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ node:
         value: nsenter
       - name: ISCSIADM_HOST_PATH
         value: /usr/local/sbin/iscsiadm
-    iscsiDirHostPath: /usr/local/etc/iscsi
+    iscsiDirHostPath: /var/iscsi
     iscsiDirHostPathType: ""
 ```
 


### PR DESCRIPTION
When `iscsi-tools` was updated from `v0.1.6` to `v0.2.0`, there were some breaking changes unfortunately not included in the patch notes. Users who use the newest version of `iscsi-tools` with the values currently in the README will get an error in the `democratic-csi-node` pod:
```
failed to apply OCI options: failed to mkdir "/usr/local/etc/iscsi": mkdir /usr/local/etc/iscsi: read-only file system`
```

This is discussed in this repo in #461 and in the siderolabs/extensions repo in [#688](https://github.com/siderolabs/extensions/issues/688)