### PR TITLE
fix(pcs): make deleteShare idempotent for missing resources

### DIFF
--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -1017,6 +1017,13 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
         response.code = 0;
       }
 
+      // Handle idempotence for delete commands — resource may have been
+      // removed by a previous interrupted attempt
+      if (response.code == 1 && response.stdout.includes("does not exist")) {
+        driver.ctx.logger.verbose("pcs resource does not exist, ignoring error (setting response.code=0)");
+        response.code = 0;
+      }
+
       if (response.code != 0) {
         throw response;
       }


### PR DESCRIPTION
Treat `does not exist` errors as success in `pcsCommand`, matching the existing `already exists` idempotence for create operations.

Without this, if the LUN was already deleted (e.g., from a previous interrupted attempt — network timeout, process crash, etc.), `deleteShare` throws before reaching the target deletion. This leaves orphaned Pacemaker target resources, leaked ZFS zvols, and PVs stuck in `Released` state with Kubernetes retrying `DeleteVolume` indefinitely.

Fixes #548