### PR TITLE
fix(pcs): make delete idempotent and use colocation constraints instead of resource group

### DIFF
--- a/hack/migrate-pcs-group-to-constraints.sh
+++ b/hack/migrate-pcs-group-to-constraints.sh
@@ -127,9 +127,9 @@ for (( i=${#TARGETS[@]}-1; i>=0; i-- )); do
   shadow_name="migrate-${pvc_id:0:20}-$$"
 
   if [[ -n "$has_lun" ]]; then
-    log "Migrating pair ($((i+1))/${#TARGETS[@]}): $target + $lun"
+    log "Migrating pair ($((${#TARGETS[@]}-i))/${#TARGETS[@]}): $target + $lun"
   else
-    log "Migrating orphan target ($((i+1))/${#TARGETS[@]}): $target"
+    log "Migrating orphan target ($((${#TARGETS[@]}-i))/${#TARGETS[@]}): $target"
   fi
 
   if $DRY_RUN; then

--- a/hack/migrate-pcs-group-to-constraints.sh
+++ b/hack/migrate-pcs-group-to-constraints.sh
@@ -5,8 +5,8 @@
 # Migrates iSCSI target/LUN Pacemaker resources from group membership to
 # standalone resources with colocation and ordering constraints.
 #
-# This eliminates cascading stop/restart of all iSCSI resources when any
-# single resource is added or removed, and enables parallel failover.
+# Each target+LUN pair is migrated as an atomic CIB update via crm_shadow.
+# If interrupted, re-run safely — already-migrated pairs are skipped.
 #
 # See: https://github.com/democratic-csi/democratic-csi/issues/547
 #
@@ -15,17 +15,14 @@
 #
 # Options:
 #   --group NAME     Pacemaker group name (default: group-nas)
-#   --sudo           Use sudo for pcs commands
 #   --dry-run        Show what would be done without making changes
 #   --help           Show this help message
 #
-# The script is idempotent — safe to run multiple times.
-# Run on the NAS host where Pacemaker is running, or via SSH.
+# Must be run as root.
 
 set -euo pipefail
 
 GROUP="group-nas"
-SUDO=""
 DRY_RUN=false
 
 usage() {
@@ -36,20 +33,16 @@ usage() {
 while [[ $# -gt 0 ]]; do
   case $1 in
     --group)   GROUP="$2"; shift 2 ;;
-    --sudo)    SUDO="sudo"; shift ;;
     --dry-run) DRY_RUN=true; shift ;;
     --help)    usage ;;
     *)         echo "Unknown option: $1"; usage ;;
   esac
 done
 
-pcs_cmd() {
-  if $DRY_RUN; then
-    echo "[dry-run] $SUDO pcs $*"
-    return 0
-  fi
-  $SUDO pcs "$@"
-}
+if [[ $EUID -ne 0 ]]; then
+  echo "Error: this script must be run as root." >&2
+  exit 1
+fi
 
 log() { echo "==> $*"; }
 warn() { echo "WARNING: $*" >&2; }
@@ -57,7 +50,7 @@ warn() { echo "WARNING: $*" >&2; }
 # --- Discover current group members ---
 
 log "Reading group '$GROUP' membership..."
-GROUP_MEMBERS=$($SUDO pcs resource group list 2>/dev/null \
+GROUP_MEMBERS=$(pcs resource group list 2>/dev/null \
   | grep "^${GROUP}:" \
   | sed "s/^${GROUP}: //" \
   | tr ' ' '\n')
@@ -67,7 +60,6 @@ if [[ -z "$GROUP_MEMBERS" ]]; then
   exit 0
 fi
 
-# Separate anchor resources (stay in group) from iSCSI resources (migrate out)
 ANCHORS=()
 TARGETS=()
 LUNS=()
@@ -75,9 +67,9 @@ ORPHAN_TARGETS=()
 
 while IFS= read -r res; do
   case "$res" in
-    target-pvc-*) TARGETS+=("$res") ;;
-    lun-pvc-*)    LUNS+=("$res") ;;
-    *)            ANCHORS+=("$res") ;;
+    target-*) TARGETS+=("$res") ;;
+    lun-*)    LUNS+=("$res") ;;
+    *)        ANCHORS+=("$res") ;;
   esac
 done <<< "$GROUP_MEMBERS"
 
@@ -87,7 +79,6 @@ echo "  Anchors (stay in group): ${ANCHORS[*]:-none}"
 echo "  iSCSI targets to migrate: ${#TARGETS[@]}"
 echo "  iSCSI LUNs to migrate: ${#LUNS[@]}"
 
-# Build a set of PVC IDs that have LUNs for orphan detection
 declare -A LUN_PVCS
 for lun in "${LUNS[@]}"; do
   pvc_id="${lun#lun-}"
@@ -121,94 +112,110 @@ if $DRY_RUN; then
 fi
 echo ""
 
-# --- Phase 1: Add constraints (while resources are still in the group) ---
-# This is non-disruptive: resources satisfy both group and constraint rules.
+# --- Migrate each target+LUN pair atomically ---
+# Iterate in reverse group order so each removal is at the tail of the
+# group, avoiding cascading stop/restart of resources that follow it.
 
-log "Phase 1: Adding colocation and ordering constraints..."
+MIGRATED=0
+FAILED=0
 
-for target in "${TARGETS[@]}"; do
+for (( i=${#TARGETS[@]}-1; i>=0; i-- )); do
+  target="${TARGETS[$i]}"
   pvc_id="${target#target-}"
+  lun="lun-${pvc_id}"
+  has_lun="${LUN_PVCS[$pvc_id]+yes}"
+  shadow_name="migrate-${pvc_id:0:20}-$$"
 
-  # Colocate target with the group anchor (same node)
-  log "  colocation: $target with $GROUP"
-  pcs_cmd constraint colocation add "$target" with "$GROUP" INFINITY 2>/dev/null || true
+  if [[ -n "$has_lun" ]]; then
+    log "Migrating pair ($((i+1))/${#TARGETS[@]}): $target + $lun"
+  else
+    log "Migrating orphan target ($((i+1))/${#TARGETS[@]}): $target"
+  fi
 
-  # Order: group must be running before target starts
-  log "  ordering:   $GROUP then $target"
-  pcs_cmd constraint order "$GROUP" then "$target" 2>/dev/null || true
+  if $DRY_RUN; then
+    echo "[dry-run] crm_shadow --create $shadow_name --batch --force"
+    echo "[dry-run] export CIB_shadow=$shadow_name"
+    if [[ -n "$has_lun" ]]; then
+      echo "[dry-run] pcs resource group remove $GROUP $lun"
+    fi
+    echo "[dry-run] pcs resource group remove $GROUP $target"
+    echo "[dry-run] pcs constraint colocation add $target with $GROUP INFINITY"
+    echo "[dry-run] pcs constraint order $GROUP then $target"
+    if [[ -n "$has_lun" ]]; then
+      echo "[dry-run] pcs constraint colocation add $lun with $target INFINITY"
+      echo "[dry-run] pcs constraint order $target then $lun"
+    fi
+    echo "[dry-run] crm_shadow --commit $shadow_name --force"
+    echo ""
+    MIGRATED=$((MIGRATED + 1))
+    continue
+  fi
+
+  crm_shadow --create "$shadow_name" --batch --force 2>/dev/null
+  export CIB_shadow="$shadow_name"
+
+  if (
+    if [[ -n "$has_lun" ]]; then
+      pcs resource group remove "$GROUP" "$lun" 2>/dev/null || true
+    fi
+
+    pcs resource group remove "$GROUP" "$target" 2>/dev/null || true
+
+    pcs constraint colocation add "$target" with "$GROUP" INFINITY 2>/dev/null || true
+    pcs constraint order "$GROUP" then "$target" 2>/dev/null || true
+
+    if [[ -n "$has_lun" ]]; then
+      pcs constraint colocation add "$lun" with "$target" INFINITY 2>/dev/null || true
+      pcs constraint order "$target" then "$lun" 2>/dev/null || true
+    fi
+  ); then
+    crm_shadow --commit "$shadow_name" --force 2>/dev/null
+    log "  committed"
+    MIGRATED=$((MIGRATED + 1))
+  else
+    warn "  failed to prepare shadow for $target, skipping"
+    FAILED=$((FAILED + 1))
+  fi
+
+  unset CIB_shadow
+  crm_shadow --delete "$shadow_name" --force 2>/dev/null || true
+  echo ""
+
+  # let pacemaker settle before the next pair
+  sleep 2
 done
 
-for lun in "${LUNS[@]}"; do
-  pvc_id="${lun#lun-}"
-  target="target-${pvc_id}"
-
-  # Colocate LUN with its target
-  log "  colocation: $lun with $target"
-  pcs_cmd constraint colocation add "$lun" with "$target" INFINITY 2>/dev/null || true
-
-  # Order: target must be running before LUN starts
-  log "  ordering:   $target then $lun"
-  pcs_cmd constraint order "$target" then "$lun" 2>/dev/null || true
-done
+# --- Report results ---
 
 echo ""
-
-# --- Phase 2: Remove iSCSI resources from the group ---
-# Resources become standalone but keep running (non-disruptive).
-# Constraints from Phase 1 ensure they stay on the correct node.
-# We remove in reverse group order (last first) to minimize recalculations.
-
-log "Phase 2: Removing iSCSI resources from group '$GROUP'..."
-
-# Build reverse-ordered list of resources to remove
-REMOVE_LIST=()
-for res in "${TARGETS[@]}" "${LUNS[@]}"; do
-  REMOVE_LIST+=("$res")
-done
-
-# Remove in reverse order
-for (( i=${#REMOVE_LIST[@]}-1; i>=0; i-- )); do
-  res="${REMOVE_LIST[$i]}"
-  log "  removing: $res"
-  pcs_cmd resource group remove "$GROUP" "$res" 2>/dev/null || true
-done
-
-echo ""
-
-# --- Phase 3: Report results ---
-
-log "Phase 3: Verifying..."
+log "Migration complete: $MIGRATED migrated, $FAILED failed"
 
 if ! $DRY_RUN; then
-  REMAINING=$($SUDO pcs resource group list 2>/dev/null \
+  echo ""
+  REMAINING=$(pcs resource group list 2>/dev/null \
     | grep "^${GROUP}:" \
     | sed "s/^${GROUP}: //")
-  echo ""
   echo "Group '$GROUP' now contains: $REMAINING"
-  echo ""
 
-  CONSTRAINT_COUNT=$($SUDO pcs constraint colocation 2>/dev/null \
-    | grep -c "target-pvc-\|lun-pvc-" || true)
+  CONSTRAINT_COUNT=$(pcs constraint colocation 2>/dev/null \
+    | grep -c "target-\|lun-" || true)
   echo "Colocation constraints for iSCSI resources: $CONSTRAINT_COUNT"
 
-  ORDER_COUNT=$($SUDO pcs constraint order 2>/dev/null \
-    | grep -c "target-pvc-\|lun-pvc-" || true)
+  ORDER_COUNT=$(pcs constraint order 2>/dev/null \
+    | grep -c "target-\|lun-" || true)
   echo "Ordering constraints for iSCSI resources: $ORDER_COUNT"
 fi
-
-echo ""
-log "Migration complete."
 
 if [[ ${#ORPHAN_TARGETS[@]} -gt 0 ]]; then
   echo ""
   warn "Orphaned targets (no matching LUN) were migrated but may need manual cleanup:"
   for t in "${ORPHAN_TARGETS[@]}"; do
-    echo "  $SUDO pcs resource delete $t"
+    echo "  pcs resource delete $t"
   done
 fi
 
 echo ""
 echo "Next steps:"
 echo "  1. Verify all iSCSI sessions are healthy: iscsiadm -m session"
-echo "  2. Check resource status: $SUDO pcs status resources"
+echo "  2. Check resource status: pcs status resources"
 echo "  3. Test failover in a maintenance window"

--- a/hack/migrate-pcs-group-to-constraints.sh
+++ b/hack/migrate-pcs-group-to-constraints.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# migrate-pcs-group-to-constraints.sh
+#
+# Migrates iSCSI target/LUN Pacemaker resources from group membership to
+# standalone resources with colocation and ordering constraints.
+#
+# This eliminates cascading stop/restart of all iSCSI resources when any
+# single resource is added or removed, and enables parallel failover.
+#
+# See: https://github.com/democratic-csi/democratic-csi/issues/547
+#
+# Usage:
+#   ./migrate-pcs-group-to-constraints.sh [options]
+#
+# Options:
+#   --group NAME     Pacemaker group name (default: group-nas)
+#   --sudo           Use sudo for pcs commands
+#   --dry-run        Show what would be done without making changes
+#   --help           Show this help message
+#
+# The script is idempotent — safe to run multiple times.
+# Run on the NAS host where Pacemaker is running, or via SSH.
+
+set -euo pipefail
+
+GROUP="group-nas"
+SUDO=""
+DRY_RUN=false
+
+usage() {
+  sed -n '2,/^$/s/^# \?//p' "$0"
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --group)   GROUP="$2"; shift 2 ;;
+    --sudo)    SUDO="sudo"; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --help)    usage ;;
+    *)         echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+pcs_cmd() {
+  if $DRY_RUN; then
+    echo "[dry-run] $SUDO pcs $*"
+    return 0
+  fi
+  $SUDO pcs "$@"
+}
+
+log() { echo "==> $*"; }
+warn() { echo "WARNING: $*" >&2; }
+
+# --- Discover current group members ---
+
+log "Reading group '$GROUP' membership..."
+GROUP_MEMBERS=$($SUDO pcs resource group list 2>/dev/null \
+  | grep "^${GROUP}:" \
+  | sed "s/^${GROUP}: //" \
+  | tr ' ' '\n')
+
+if [[ -z "$GROUP_MEMBERS" ]]; then
+  echo "Group '$GROUP' not found or empty. Nothing to migrate."
+  exit 0
+fi
+
+# Separate anchor resources (stay in group) from iSCSI resources (migrate out)
+ANCHORS=()
+TARGETS=()
+LUNS=()
+ORPHAN_TARGETS=()
+
+while IFS= read -r res; do
+  case "$res" in
+    target-pvc-*) TARGETS+=("$res") ;;
+    lun-pvc-*)    LUNS+=("$res") ;;
+    *)            ANCHORS+=("$res") ;;
+  esac
+done <<< "$GROUP_MEMBERS"
+
+echo ""
+echo "Group '$GROUP' contains:"
+echo "  Anchors (stay in group): ${ANCHORS[*]:-none}"
+echo "  iSCSI targets to migrate: ${#TARGETS[@]}"
+echo "  iSCSI LUNs to migrate: ${#LUNS[@]}"
+
+# Build a set of PVC IDs that have LUNs for orphan detection
+declare -A LUN_PVCS
+for lun in "${LUNS[@]}"; do
+  pvc_id="${lun#lun-}"
+  LUN_PVCS["$pvc_id"]=1
+done
+
+for target in "${TARGETS[@]}"; do
+  pvc_id="${target#target-}"
+  if [[ -z "${LUN_PVCS[$pvc_id]+x}" ]]; then
+    ORPHAN_TARGETS+=("$target")
+  fi
+done
+
+if [[ ${#ORPHAN_TARGETS[@]} -gt 0 ]]; then
+  echo ""
+  warn "Found ${#ORPHAN_TARGETS[@]} orphaned target(s) without matching LUN:"
+  for t in "${ORPHAN_TARGETS[@]}"; do
+    echo "    $t"
+  done
+fi
+
+TOTAL=$((${#TARGETS[@]} + ${#LUNS[@]}))
+if [[ $TOTAL -eq 0 ]]; then
+  echo "No iSCSI resources to migrate."
+  exit 0
+fi
+
+echo ""
+if $DRY_RUN; then
+  echo "--- DRY RUN MODE (no changes will be made) ---"
+fi
+echo ""
+
+# --- Phase 1: Add constraints (while resources are still in the group) ---
+# This is non-disruptive: resources satisfy both group and constraint rules.
+
+log "Phase 1: Adding colocation and ordering constraints..."
+
+for target in "${TARGETS[@]}"; do
+  pvc_id="${target#target-}"
+
+  # Colocate target with the group anchor (same node)
+  log "  colocation: $target with $GROUP"
+  pcs_cmd constraint colocation add "$target" with "$GROUP" INFINITY 2>/dev/null || true
+
+  # Order: group must be running before target starts
+  log "  ordering:   $GROUP then $target"
+  pcs_cmd constraint order "$GROUP" then "$target" 2>/dev/null || true
+done
+
+for lun in "${LUNS[@]}"; do
+  pvc_id="${lun#lun-}"
+  target="target-${pvc_id}"
+
+  # Colocate LUN with its target
+  log "  colocation: $lun with $target"
+  pcs_cmd constraint colocation add "$lun" with "$target" INFINITY 2>/dev/null || true
+
+  # Order: target must be running before LUN starts
+  log "  ordering:   $target then $lun"
+  pcs_cmd constraint order "$target" then "$lun" 2>/dev/null || true
+done
+
+echo ""
+
+# --- Phase 2: Remove iSCSI resources from the group ---
+# Resources become standalone but keep running (non-disruptive).
+# Constraints from Phase 1 ensure they stay on the correct node.
+# We remove in reverse group order (last first) to minimize recalculations.
+
+log "Phase 2: Removing iSCSI resources from group '$GROUP'..."
+
+# Build reverse-ordered list of resources to remove
+REMOVE_LIST=()
+for res in "${TARGETS[@]}" "${LUNS[@]}"; do
+  REMOVE_LIST+=("$res")
+done
+
+# Remove in reverse order
+for (( i=${#REMOVE_LIST[@]}-1; i>=0; i-- )); do
+  res="${REMOVE_LIST[$i]}"
+  log "  removing: $res"
+  pcs_cmd resource group remove "$GROUP" "$res" 2>/dev/null || true
+done
+
+echo ""
+
+# --- Phase 3: Report results ---
+
+log "Phase 3: Verifying..."
+
+if ! $DRY_RUN; then
+  REMAINING=$($SUDO pcs resource group list 2>/dev/null \
+    | grep "^${GROUP}:" \
+    | sed "s/^${GROUP}: //")
+  echo ""
+  echo "Group '$GROUP' now contains: $REMAINING"
+  echo ""
+
+  CONSTRAINT_COUNT=$($SUDO pcs constraint colocation 2>/dev/null \
+    | grep -c "target-pvc-\|lun-pvc-" || true)
+  echo "Colocation constraints for iSCSI resources: $CONSTRAINT_COUNT"
+
+  ORDER_COUNT=$($SUDO pcs constraint order 2>/dev/null \
+    | grep -c "target-pvc-\|lun-pvc-" || true)
+  echo "Ordering constraints for iSCSI resources: $ORDER_COUNT"
+fi
+
+echo ""
+log "Migration complete."
+
+if [[ ${#ORPHAN_TARGETS[@]} -gt 0 ]]; then
+  echo ""
+  warn "Orphaned targets (no matching LUN) were migrated but may need manual cleanup:"
+  for t in "${ORPHAN_TARGETS[@]}"; do
+    echo "  $SUDO pcs resource delete $t"
+  done
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Verify all iSCSI sessions are healthy: iscsiadm -m session"
+echo "  2. Check resource status: $SUDO pcs status resources"
+echo "  3. Test failover in a maintenance window"

--- a/hack/migrate-pcs-group-to-constraints.sh
+++ b/hack/migrate-pcs-group-to-constraints.sh
@@ -139,9 +139,11 @@ for (( i=${#TARGETS[@]}-1; i>=0; i-- )); do
       echo "[dry-run] pcs resource group remove $GROUP $lun"
     fi
     echo "[dry-run] pcs resource group remove $GROUP $target"
+    echo "[dry-run] pcs resource update $target op start timeout=30s op stop timeout=30s"
     echo "[dry-run] pcs constraint colocation add $target with $GROUP INFINITY"
     echo "[dry-run] pcs constraint order $GROUP then $target"
     if [[ -n "$has_lun" ]]; then
+      echo "[dry-run] pcs resource update $lun op start timeout=30s op stop timeout=30s"
       echo "[dry-run] pcs constraint colocation add $lun with $target INFINITY"
       echo "[dry-run] pcs constraint order $target then $lun"
     fi
@@ -161,10 +163,12 @@ for (( i=${#TARGETS[@]}-1; i>=0; i-- )); do
 
     pcs resource group remove "$GROUP" "$target" 2>/dev/null || true
 
+    pcs resource update "$target" op start timeout=30s op stop timeout=30s 2>/dev/null || true
     pcs constraint colocation add "$target" with "$GROUP" INFINITY 2>/dev/null || true
     pcs constraint order "$GROUP" then "$target" 2>/dev/null || true
 
     if [[ -n "$has_lun" ]]; then
+      pcs resource update "$lun" op start timeout=30s op stop timeout=30s 2>/dev/null || true
       pcs constraint colocation add "$lun" with "$target" INFINITY 2>/dev/null || true
       pcs constraint order "$target" then "$lun" 2>/dev/null || true
     fi

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -308,12 +308,6 @@ create /backstores/block/${assetName}
               basename = this.options.iscsi.shareStrategyPcs.basename;
               let pcs_group = this.options.iscsi.shareStrategyPcs.pcs_group;
 
-              // Create resources as standalone (not in the group) and use
-              // colocation/ordering constraints instead. Adding resources
-              // directly to a Pacemaker group causes cascading stop/restart
-              // of all sibling resources on every add/remove operation,
-              // which breaks active iSCSI sessions.
-              // See: https://github.com/democratic-csi/democratic-csi/issues/547
               let createTargetTerms = [
                 'resource', 'create', '--future', '--force', `target-${assetName}`, 'ocf:heartbeat:iSCSITarget',
                 'implementation="lio-t"', 'portals=":::3260"', `iqn="${basename}:${assetName}"`
@@ -324,63 +318,44 @@ create /backstores/block/${assetName}
                 createTargetTerms.push(`incoming_password="${this.options.iscsi.shareStrategyPcs.auth.incoming_password}"`);
               }
 
-              await GeneralUtils.retry(
-                3,
-                2000,
-                async () => {
-                  await this.pcsCommand(createTargetTerms.concat(['--wait']));
-                },
-                {
-                  retryCondition: (err) => {
-                    if (err.stdout && err.stdout.includes("Timed Out")) {
-                      return true;
-                    }
-                    return false;
-                  },
-                }
-              );
+              // create stopped so constraints are in place before pacemaker starts it
+              createTargetTerms.push('meta', 'target-role=Stopped');
 
-              // Pin target to the same node as the resource group (pool + VIP)
-              await this.pcsCommand([
+              await this.pcsCommandWithTimeoutRetry(createTargetTerms);
+
+              await this.pcsCommandWithTimeoutRetry([
                 'constraint', 'colocation', 'add',
                 `target-${assetName}`, 'with', pcs_group, 'INFINITY'
               ]);
 
-              // Ensure the group (pool + VIP) is running before the target starts
-              await this.pcsCommand([
+              await this.pcsCommandWithTimeoutRetry([
                 'constraint', 'order', pcs_group, 'then', `target-${assetName}`
+              ]);
+
+              await this.pcsCommandWithTimeoutRetry([
+                'resource', 'enable', `target-${assetName}`
               ]);
 
               let createLunTerms = [
                 'resource', 'create', '--future', `lun-${assetName}`, 'ocf:heartbeat:iSCSILogicalUnit',
                 'implementation="lio-t"', `target_iqn="${basename}:${assetName}"`, 'lun="0"',
-                `path="/dev/${extentDiskName}"`
+                `path="/dev/${extentDiskName}"`,
+                'meta', 'target-role=Stopped'
               ];
 
-              await GeneralUtils.retry(
-                3,
-                2000,
-                async () => {
-                  await this.pcsCommand(createLunTerms.concat(['--wait']));
-                },
-                {
-                  retryCondition: (err) => {
-                    if (err.stdout && err.stdout.includes("Timed Out")) {
-                      return true;
-                    }
-                    return false;
-                  },
-                }
-              );
+              await this.pcsCommandWithTimeoutRetry(createLunTerms);
 
-              // LUN must be on the same node and start after its target
-              await this.pcsCommand([
+              await this.pcsCommandWithTimeoutRetry([
                 'constraint', 'colocation', 'add',
                 `lun-${assetName}`, 'with', `target-${assetName}`, 'INFINITY'
               ]);
 
-              await this.pcsCommand([
+              await this.pcsCommandWithTimeoutRetry([
                 'constraint', 'order', `target-${assetName}`, 'then', `lun-${assetName}`
+              ]);
+
+              await this.pcsCommandWithTimeoutRetry([
+                'resource', 'enable', `lun-${assetName}`
               ]);
 
               break;
@@ -781,71 +756,13 @@ delete ${assetName}
 
             break;
           case "pcs":
-            // Brownfield safety: if the resource is in a Pacemaker group
-            // (legacy behavior), remove it from the group first. This
-            // prevents cascading stop/restart of other group members.
-            // Removing from a group is non-disruptive — the resource
-            // becomes standalone and keeps running. If the resource is
-            // already standalone (new behavior) or doesn't exist, the
-            // group remove will fail harmlessly.
-            let pcs_group_delete = this.options.iscsi.shareStrategyPcs.pcs_group;
-
-            for (let resName of [`lun-${assetName}`, `target-${assetName}`]) {
-              try {
-                await this.pcsCommand([
-                  'resource', 'group', 'remove', pcs_group_delete, resName
-                ]);
-                this.ctx.logger.info(
-                  `removed ${resName} from group ${pcs_group_delete} before deletion`
-                );
-              } catch (err) {
-                // Resource not in group or doesn't exist — expected for
-                // new deployments or already-cleaned-up resources
-                this.ctx.logger.verbose(
-                  `${resName} not in group ${pcs_group_delete} (may be standalone or absent), continuing`
-                );
-              }
-            }
-
-            let deleteLunText = [
+            await this.pcsCommandWithTimeoutRetry([
               'resource', 'delete', `lun-${assetName}`
-            ];
+            ]);
 
-            await GeneralUtils.retry(
-              3,
-              2000,
-              async () => {
-                await this.pcsCommand(deleteLunText);
-              },
-              {
-                retryCondition: (err) => {
-                  if (err.stdout && err.stdout.includes("Timed Out")) {
-                    return true;
-                  }
-                  return false;
-                },
-              }
-            );
-
-            let deleteTargetText = [
+            await this.pcsCommandWithTimeoutRetry([
               'resource', 'delete', `target-${assetName}`
-            ];
-
-            await GeneralUtils.retry(
-              3,
-              2000,
-              async () => {
-                await this.pcsCommand(deleteTargetText);
-              },
-              {
-                retryCondition: (err) => {
-                  if (err.stdout && err.stdout.includes("Timed Out")) {
-                    return true;
-                  }
-                  return false;
-                },
-              }
-            );
+            ]);
 
             break;
 
@@ -1063,12 +980,13 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
         "pcs response: " + JSON.stringify(response)
       );
           
-      // Handle idempotence for create and constraint commands
+      // Handle idempotence for create commands
       if (response.code == 1 && response.stdout.includes("already exists")) {
         driver.ctx.logger.verbose("pcs resource already exists, ignoring error (setting response.code=0)");
         response.code = 0;
       }
 
+      // Handle idempotence for constraint commands
       if (response.code == 1 && response.stdout.includes("duplicate")) {
         driver.ctx.logger.verbose("pcs constraint duplicate, ignoring error (setting response.code=0)");
         response.code = 0;
@@ -1079,6 +997,24 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
       }
       return response;
     });
+  }
+
+  async pcsCommandWithTimeoutRetry(commandTerms) {
+    return GeneralUtils.retry(
+      3,
+      2000,
+      async () => {
+        await this.pcsCommand(commandTerms);
+      },
+      {
+        retryCondition: (err) => {
+          if (err.stdout && err.stdout.includes("Timed Out")) {
+            return true;
+          }
+          return false;
+        },
+      }
+    );
   }
 
   async targetCliCommand(data) {

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -318,6 +318,12 @@ create /backstores/block/${assetName}
                 createTargetTerms.push(`incoming_password="${this.options.iscsi.shareStrategyPcs.auth.incoming_password}"`);
               }
 
+              createTargetTerms.push(
+                'op', 'start', 'timeout=30s',
+                'op', 'stop', 'timeout=30s',
+                'op', 'monitor', 'interval=10s', 'timeout=10s'
+              );
+
               // create stopped so constraints are in place before pacemaker starts it
               createTargetTerms.push('meta', 'target-role=Stopped');
 
@@ -340,6 +346,9 @@ create /backstores/block/${assetName}
                 'resource', 'create', '--future', `lun-${assetName}`, 'ocf:heartbeat:iSCSILogicalUnit',
                 'implementation="lio-t"', `target_iqn="${basename}:${assetName}"`, 'lun="0"',
                 `path="/dev/${extentDiskName}"`,
+                'op', 'start', 'timeout=30s',
+                'op', 'stop', 'timeout=30s',
+                'op', 'monitor', 'interval=10s', 'timeout=10s',
                 'meta', 'target-role=Stopped'
               ];
 

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -992,6 +992,12 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
         response.code = 0;
       }
 
+      // Handle idempotence for delete commands
+      if (response.code == 1 && response.stdout.includes("does not exist")) {
+        driver.ctx.logger.verbose("pcs resource does not exist, ignoring error (setting response.code=0)");
+        response.code = 0;
+      }
+
       if (response.code != 0) {
         throw response;
       }

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -308,7 +308,12 @@ create /backstores/block/${assetName}
               basename = this.options.iscsi.shareStrategyPcs.basename;
               let pcs_group = this.options.iscsi.shareStrategyPcs.pcs_group;
 
-              let extraTerms = ['group', `${pcs_group}`, '--wait']; // The wait is important to avoid race conditions
+              // Create resources as standalone (not in the group) and use
+              // colocation/ordering constraints instead. Adding resources
+              // directly to a Pacemaker group causes cascading stop/restart
+              // of all sibling resources on every add/remove operation,
+              // which breaks active iSCSI sessions.
+              // See: https://github.com/democratic-csi/democratic-csi/issues/547
               let createTargetTerms = [
                 'resource', 'create', '--future', '--force', `target-${assetName}`, 'ocf:heartbeat:iSCSITarget',
                 'implementation="lio-t"', 'portals=":::3260"', `iqn="${basename}:${assetName}"`
@@ -323,7 +328,7 @@ create /backstores/block/${assetName}
                 3,
                 2000,
                 async () => {
-                  await this.pcsCommand(createTargetTerms.concat(extraTerms));
+                  await this.pcsCommand(createTargetTerms.concat(['--wait']));
                 },
                 {
                   retryCondition: (err) => {
@@ -334,6 +339,17 @@ create /backstores/block/${assetName}
                   },
                 }
               );
+
+              // Pin target to the same node as the resource group (pool + VIP)
+              await this.pcsCommand([
+                'constraint', 'colocation', 'add',
+                `target-${assetName}`, 'with', pcs_group, 'INFINITY'
+              ]);
+
+              // Ensure the group (pool + VIP) is running before the target starts
+              await this.pcsCommand([
+                'constraint', 'order', pcs_group, 'then', `target-${assetName}`
+              ]);
 
               let createLunTerms = [
                 'resource', 'create', '--future', `lun-${assetName}`, 'ocf:heartbeat:iSCSILogicalUnit',
@@ -345,7 +361,7 @@ create /backstores/block/${assetName}
                 3,
                 2000,
                 async () => {
-                  await this.pcsCommand(createLunTerms.concat(extraTerms));
+                  await this.pcsCommand(createLunTerms.concat(['--wait']));
                 },
                 {
                   retryCondition: (err) => {
@@ -356,7 +372,17 @@ create /backstores/block/${assetName}
                   },
                 }
               );
-  
+
+              // LUN must be on the same node and start after its target
+              await this.pcsCommand([
+                'constraint', 'colocation', 'add',
+                `lun-${assetName}`, 'with', `target-${assetName}`, 'INFINITY'
+              ]);
+
+              await this.pcsCommand([
+                'constraint', 'order', `target-${assetName}`, 'then', `lun-${assetName}`
+              ]);
+
               break;
 
           default:
@@ -755,6 +781,32 @@ delete ${assetName}
 
             break;
           case "pcs":
+            // Brownfield safety: if the resource is in a Pacemaker group
+            // (legacy behavior), remove it from the group first. This
+            // prevents cascading stop/restart of other group members.
+            // Removing from a group is non-disruptive — the resource
+            // becomes standalone and keeps running. If the resource is
+            // already standalone (new behavior) or doesn't exist, the
+            // group remove will fail harmlessly.
+            let pcs_group_delete = this.options.iscsi.shareStrategyPcs.pcs_group;
+
+            for (let resName of [`lun-${assetName}`, `target-${assetName}`]) {
+              try {
+                await this.pcsCommand([
+                  'resource', 'group', 'remove', pcs_group_delete, resName
+                ]);
+                this.ctx.logger.info(
+                  `removed ${resName} from group ${pcs_group_delete} before deletion`
+                );
+              } catch (err) {
+                // Resource not in group or doesn't exist — expected for
+                // new deployments or already-cleaned-up resources
+                this.ctx.logger.verbose(
+                  `${resName} not in group ${pcs_group_delete} (may be standalone or absent), continuing`
+                );
+              }
+            }
+
             let deleteLunText = [
               'resource', 'delete', `lun-${assetName}`
             ];
@@ -1011,9 +1063,14 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
         "pcs response: " + JSON.stringify(response)
       );
           
-      // Handle idempotence for create commands
+      // Handle idempotence for create and constraint commands
       if (response.code == 1 && response.stdout.includes("already exists")) {
         driver.ctx.logger.verbose("pcs resource already exists, ignoring error (setting response.code=0)");
+        response.code = 0;
+      }
+
+      if (response.code == 1 && response.stdout.includes("duplicate")) {
+        driver.ctx.logger.verbose("pcs constraint duplicate, ignoring error (setting response.code=0)");
         response.code = 0;
       }
 


### PR DESCRIPTION
## Summary

Replaces resource group membership with colocation/ordering constraints for iSCSI Pacemaker resources.

## Problem

All iSCSI resources were added to a single Pacemaker resource group. Groups enforce implicit ordering — when any resource is added or removed, Pacemaker stops and restarts sibling resources. This causes active iSCSI sessions to break with I/O errors and filesystem crashes. See #547 for full details.

## Fix

- Create iSCSI target/LUN resources as standalone with `meta target-role=Stopped`, add colocation and ordering constraints, then enable. This ensures Pacemaker starts them on the correct node without a race window.
- Make delete operations idempotent for already-removed resources, preventing orphaned Pacemaker resources and stuck PVs (#548).
- Include a migration script (`hack/migrate-pcs-group-to-constraints.sh`) for brownfield deployments. It uses `crm_shadow` to batch each target+LUN pair as an atomic CIB update, iterating in reverse group order to avoid cascading restarts.

Fixes #547
Fixes #548