### PR TITLE
Add _netdev to network block device mount options

### DIFF
--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -1630,6 +1630,17 @@ class CsiBaseDriver {
               }
             }
 
+            // For network mounts, attach _netdev
+            // to make systemd handle dependencies correctly at shutdown
+            switch (node_attach_driver) {
+              case "iscsi":
+              case "nvmeof":
+                mount_flags.push("_netdev")
+                break;
+              default:
+                break;
+            }
+
             // mount `device`
             result = await mount.deviceIsMountedAtPath(
               device,


### PR DESCRIPTION
Under systemd, a network block device mount needs to be mounted with `_netdev` mount option, so systemd could correctly recognize it as a remote filesystem.

Without this option, at shutdown, systemd could potentially shutdown network interface **before** the NVME-of / iSCSI mount is unmounted, resulting in the unmount hanging waiting for syncing until block device layer timeouts, risking data corruption in the process. `_netdev` automatically orders the unmount to commence before network is shutdown.

This PR adds this mount option to all NVME-of/iSCSI mounts.