### PR TITLE
Added ZFS virtiofs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ have access to resizing, snapshots, clones, etc functionality.
   - `zfs-generic-iscsi` (works with any ZoL installation...ie: Ubuntu)
   - `zfs-generic-smb` (works with any ZoL installation...ie: Ubuntu)
   - `zfs-generic-nvmeof` (works with any ZoL installation...ie: Ubuntu)
+  - `zfs-generic-virtiofs` (works with ZoL + virtiofs passthrough)
   - `zfs-local-ephemeral-inline` (provisions node-local zfs datasets)
   - `zfs-local-dataset` (provision node-local volume as dataset)
   - `zfs-local-zvol` (provision node-local volume as zvol)
@@ -434,7 +435,7 @@ Issues to review:
 - https://jira.ixsystems.com/browse/NAS-108522
 - https://jira.ixsystems.com/browse/NAS-107219
 
-### ZoL (zfs-generic-nfs, zfs-generic-iscsi, zfs-generic-smb, zfs-generic-nvmeof)
+### ZoL (zfs-generic-nfs, zfs-generic-iscsi, zfs-generic-smb, zfs-generic-nvmeof, zfs-generic-virtiofs)
 
 Ensure ssh and zfs is installed on the nfs/iscsi server and that you have installed
 `targetcli`.

--- a/docker/mount
+++ b/docker/mount
@@ -20,29 +20,30 @@ container_supported_filesystems=(
   "bind"
 )
 
-while getopts "t:" opt; do
-  case "$opt" in
-    t)
-      if [[ "x${USE_HOST_MOUNT_TOOLS}" == "x" ]]; then
-        [[ "${OPTARG,,}" == "zfs" ]] && USE_HOST_MOUNT_TOOLS=1
-        [[ "${OPTARG,,}" == "lustre" ]] && USE_HOST_MOUNT_TOOLS=1
-        [[ "${OPTARG,,}" == "onedata" ]] && USE_HOST_MOUNT_TOOLS=1
-        #(printf '%s\0' "${container_supported_filesystems[@]}" | grep -Fqxz -- "${OPTARG}") || USE_HOST_MOUNT_TOOLS=1
-      fi
-      ;;
-  esac
+# Parse arguments to detect filesystem type without consuming them
+for arg in "$@"; do
+  if [[ "$prev_arg" == "-t" ]]; then
+    if [[ "x${USE_HOST_MOUNT_TOOLS}" == "x" ]]; then
+      [[ "${arg,,}" == "zfs" ]] && USE_HOST_MOUNT_TOOLS=1
+      [[ "${arg,,}" == "lustre" ]] && USE_HOST_MOUNT_TOOLS=1
+      [[ "${arg,,}" == "onedata" ]] && USE_HOST_MOUNT_TOOLS=1
+      #(printf '%s\0' "${container_supported_filesystems[@]}" | grep -Fqxz -- "${arg}") || USE_HOST_MOUNT_TOOLS=1
+    fi
+    break
+  fi
+  prev_arg="$arg"
 done
 
 if [[ ${USE_HOST_MOUNT_TOOLS} -eq 1 ]]; then
   for p in $(echo $P | cut -d ":" -f 1- --output-delimiter=" "); do
     if [[ -f "/host${p}/mount" ]]; then
-      chroot /host "${p}/mount" "${@:1}"
+      chroot /host "${p}/mount" "$@"
       exit $?
     fi
   done
-  chroot /host /usr/bin/env -i PATH="${P}" mount "${@:1}"
+  chroot /host /usr/bin/env -i PATH="${P}" mount "$@"
   exit $?
 else
-  /usr/bin/env -i PATH="${PL}" mount "${@:1}"
+  /usr/bin/env -i PATH="${PL}" mount "$@"
   exit $?
 fi

--- a/examples/zfs-generic-virtiofs.yaml
+++ b/examples/zfs-generic-virtiofs.yaml
@@ -1,0 +1,60 @@
+driver: zfs-generic-virtiofs
+sshConnection:
+  host: server address
+  port: 22
+  username: root
+  # use either password or key
+  password: ""
+  privateKey: |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
+
+zfs:
+  # can be used to override defaults if necessary
+  # the example below is useful for TrueNAS 12
+  #cli:
+  #  sudoEnabled: true
+  #  paths:
+  #    zfs: /usr/local/sbin/zfs
+  #    zpool: /usr/local/sbin/zpool
+  #    sudo: /usr/local/bin/sudo
+  #    chroot: /usr/sbin/chroot
+
+  # can be used to set arbitrary values on the dataset/zvol
+  # can use handlebars templates with the parameters from the storage class/CO
+  #datasetProperties:
+  #  "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
+  #  "org.freenas:test": "{{ parameters.foo }}"
+  #  "org.freenas:test2": "some value"
+  # snapshotProperties:
+  #  "org.freenas:key": "value"
+
+  datasetParentName: tank/k8s/test
+  # do NOT make datasetParentName and detachedSnapshotsDatasetParentName overlap
+  # they may be siblings, but neither should be nested in the other
+  # do NOT comment this option out even if you don't plan to use snapshots, just leave it with dummy value
+  detachedSnapshotsDatasetParentName: tanks/k8s/test-snapshots
+
+  datasetEnableQuotas: true
+  datasetEnableReservation: false
+  datasetPermissionsMode: "0777"
+  datasetPermissionsUser: 0
+  datasetPermissionsGroup: 0
+  #datasetPermissionsAcls:
+  #- "-m everyone@:full_set:allow"
+  #- "-m u:kube:full_set:allow"
+
+virtiofs:
+  # The base path on the remote ZFS host where datasets are mounted
+  # This should match the parent of your datasetParentName
+  # For example, if datasetParentName is "tank/k8s/test",
+  # and tank is mounted at /tank, then remoteBasePath would be "/tank/k8s/test"
+  remoteBasePath: "/tank/k8s/test"
+
+  # The local path where the virtiofs share is mounted on the Kubernetes nodes
+  # The virtiofs share should expose the remoteBasePath directory
+  # For example, if you configure virtiofs to share /tank/k8s/test from the host,
+  # and mount it at /mnt/virtiofs-storage on the guest, use "/mnt/virtiofs-storage"
+  localMountPath: "/mnt/virtiofs-storage"
+

--- a/src/driver/controller-zfs-generic/index.js
+++ b/src/driver/controller-zfs-generic/index.js
@@ -72,6 +72,7 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
     switch (this.options.driver) {
       case "zfs-generic-nfs":
       case "zfs-generic-smb":
+      case "zfs-generic-virtiofs":
         return "filesystem";
       case "zfs-generic-iscsi":
       case "zfs-generic-nvmeof":
@@ -181,6 +182,34 @@ class ControllerZfsGenericDriver extends ControllerZfsBaseDriver {
           node_attach_driver: "smb",
           server: this.options.smb.shareHost,
           share,
+        };
+        return volume_context;
+
+      case "zfs-generic-virtiofs":
+        // For virtiofs, we get the remote mountpoint and convert it to a local path
+        properties = await zb.zfs.get(datasetName, ["mountpoint"]);
+        properties = properties[datasetName];
+        this.ctx.logger.debug("zfs props data: %j", properties);
+
+        // The remote mountpoint path needs to be converted to the local virtiofs path
+        // by replacing the remote base path with the local mount path
+        const remoteMountpoint = properties.mountpoint.value;
+        const remoteBasePath = this.options.virtiofs.remoteBasePath;
+        const localMountPath = this.options.virtiofs.localMountPath;
+
+        if (!remoteMountpoint.startsWith(remoteBasePath)) {
+          throw new GrpcError(
+            grpc.status.FAILED_PRECONDITION,
+            `dataset mountpoint ${remoteMountpoint} does not start with configured remoteBasePath ${remoteBasePath}`
+          );
+        }
+
+        // Replace remote base path with local mount path
+        const localPath = remoteMountpoint.replace(remoteBasePath, localMountPath);
+
+        volume_context = {
+          node_attach_driver: "hostpath",
+          path: localPath,
         };
         return volume_context;
 
@@ -686,6 +715,11 @@ save_config filename=${this.options.nvmeof.shareStrategySpdkCli.configPath}
               `invalid configuration: unknown shareStrategy ${this.options.smb.shareStrategy}`
             );
         }
+        break;
+
+      case "zfs-generic-virtiofs":
+        // For virtiofs, there's nothing to clean up
+        // The dataset will be destroyed by the base driver
         break;
 
       case "zfs-generic-iscsi": {

--- a/src/driver/factory.js
+++ b/src/driver/factory.js
@@ -50,6 +50,7 @@ function factory(ctx, options) {
     case "zfs-generic-smb":
     case "zfs-generic-iscsi":
     case "zfs-generic-nvmeof":
+    case "zfs-generic-virtiofs":
       return new ControllerZfsGenericDriver(ctx, options);
     case "zfs-local-dataset":
     case "zfs-local-zvol":


### PR DESCRIPTION
This PR adds a new `zfs-generic-virtiofs` driver that enables ZFS volume provisioning for Kubernetes clusters running as VMs with virtiofs filesystem sharing. The driver manages ZFS datasets on a remote host via SSH while volumes are accessed locally through virtiofs mounts, providing a lightweight alternative to network-based protocols like NFS or iSCSI. 

Internally, the driver is a combination of `zfs-generic-*` and `local-hostpath`. The implementation includes path translation between remote ZFS mountpoints and local virtiofs mount paths, along with improved argument parsing to support multi-character command-line arguments.

This has been tested on a single-noded [Talos](https://www.talos.dev/) cluster running on [Proxmox](https://proxmox.com/), which also served as the ZFS host.


Closes #419 
