### PR TITLE
Add support for zvol parameter overrides in freenas-api

### DIFF
--- a/docs/storage-class-parameters.md
+++ b/docs/storage-class-parameters.md
@@ -176,6 +176,14 @@ Only the following options may be overridden. Any other value present in an over
 The `zvol*` options only have an effect on the block drivers (`iscsi` / `nvmeof`), which create a ZFS `volume`. For the
 `nfs` / `smb` drivers (which create a ZFS `filesystem`) only `zfs.datasetProperties` is meaningful.
 
+> **Note on `datasetPermissionsAcls` (dataset ACLs):** This option is applied by the **SSH-based** drivers
+> (`freenas-*` / `truenas-*`, `zfs-generic-*`), which shell out to `setfacl` (see `datasetPermissionsAclsBinary`).
+> It is **not** applied by the **API-based** drivers (`freenas-api-*` / `truenas-api-*`) and is silently ignored there.
+> The config value is a list of raw `setfacl`-style argument strings, whereas the TrueNAS `filesystem.setacl` API expects
+> a structured ACE (`dacl`) payload that differs between NFSv4 and POSIX1e ACLs, so there is no safe automatic
+> translation. Note that `datasetPermissionsAcls` is **not** an overridable option in either driver — it can only be set
+> in the driver configuration.
+
 ### Per-`StorageClass` override
 
 Add a `config` parameter to the `StorageClass` containing a YAML/JSON document with the options to override. The document

--- a/docs/storage-class-parameters.md
+++ b/docs/storage-class-parameters.md
@@ -146,3 +146,98 @@ missing CHAP authentication will not be enabled (but the volume will still be cr
 enable/disable CHAP or change the password after the volume has been created.
 
 If the secret itself is referenced but not present, the volume will not be created.
+
+## ZFS drivers (`zfs-generic-*`, `zfs-local-*`, `freenas-*`/`truenas-*`, `freenas-api-*`/`truenas-api-*`)
+
+By default the ZFS/dataset options are taken from the driver configuration and apply to every volume the driver
+provisions. A subset of these options can additionally be overridden on a **per-`StorageClass`** and even
+**per-`PersistentVolumeClaim`** basis, allowing different volumes to use different settings without deploying multiple
+driver instances.
+
+This is supported by all ZFS-backed drivers:
+
+- `zfs-generic-nfs`, `zfs-generic-smb`, `zfs-generic-iscsi`, `zfs-generic-nvmeof`
+- `zfs-local-dataset`, `zfs-local-zvol`
+- `freenas-nfs`, `freenas-smb`, `freenas-iscsi`, `freenas-nvmeof` (and the `truenas-*` aliases) — SSH-based
+- `freenas-api-nfs`, `freenas-api-smb`, `freenas-api-iscsi`, `freenas-api-nvmeof` (and the `truenas-api-*` aliases) — API-based
+
+### Overridable options
+
+Only the following options may be overridden. Any other value present in an override document is ignored:
+
+| Option | Applies to | Notes |
+| --- | --- | --- |
+| `zfs.zvolBlocksize` | `iscsi` / `nvmeof` (block volumes) | Only honored at volume **creation** time; `volblocksize` is immutable afterwards. |
+| `zfs.zvolDedup` | `iscsi` / `nvmeof` (block volumes) | e.g. `on`, `off`, `verify`. |
+| `zfs.zvolCompression` | `iscsi` / `nvmeof` (block volumes) | e.g. `lz4`, `gzip-9`. |
+| `zfs.zvolEnableReservation` | `iscsi` / `nvmeof` (block volumes) | Controls sparse vs. reserved (thick) volumes. |
+| `zfs.datasetProperties` | all | Arbitrary ZFS properties applied to the dataset. Supports Handlebars templating against `parameters`. |
+
+The `zvol*` options only have an effect on the block drivers (`iscsi` / `nvmeof`), which create a ZFS `volume`. For the
+`nfs` / `smb` drivers (which create a ZFS `filesystem`) only `zfs.datasetProperties` is meaningful.
+
+### Per-`StorageClass` override
+
+Add a `config` parameter to the `StorageClass` containing a YAML/JSON document with the options to override. The document
+mirrors the structure of the driver configuration file:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: freenas-iscsi-16k
+parameters:
+  fsType: ext4
+  config: |
+    zfs:
+      zvolBlocksize: "16K"
+      zvolCompression: "lz4"
+      zvolDedup: "off"
+      zvolEnableReservation: false
+      datasetProperties:
+        # Handlebars templating against the CSI request parameters is supported
+        comments: "provisioned for {{ parameters.[csi.storage.k8s.io/pvc/namespace] }}"
+provisioner: org.democratic-csi.iscsi
+```
+
+### Per-`PersistentVolumeClaim` override
+
+To let individual PVCs override options, enable `load-config-from-pvc` on the `StorageClass` and place the override
+document in the PVC's `democratic-csi.org/config` annotation:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: freenas-iscsi
+parameters:
+  fsType: ext4
+  load-config-from-pvc: "true"
+provisioner: org.democratic-csi.iscsi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-fast-volume
+  annotations:
+    democratic-csi.org/config: |
+      zfs:
+        zvolBlocksize: "64K"
+        zvolCompression: "off"
+spec:
+  storageClassName: freenas-iscsi
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+Reading the PVC requires the external-provisioner to forward PVC metadata to the driver (i.e. it must be started with
+`--extra-create-metadata=true`, which is the default in the democratic-csi charts). When enabled, the effective options
+are resolved in the following order of increasing precedence: driver configuration → `StorageClass` `config` →
+PVC `democratic-csi.org/config` annotation.
+
+> The `config` parameter (and the `democratic-csi.org/config` annotation) may also be namespaced per-driver or
+> per-instance using the standard prefixes, e.g. `democratic-csi.org/config`,
+> `democratic-csi.org/<driver>/config` or `democratic-csi.org/<instance_id>/config`.

--- a/examples/freenas-api-nfs.yaml
+++ b/examples/freenas-api-nfs.yaml
@@ -47,7 +47,7 @@ zfs:
   datasetPermissionsUser: 0
   datasetPermissionsGroup: 0
 
-  # not supported yet
+  # not supported yet in api (silently ignored); use an SSH-based driver if you need dataset ACLs
   #datasetPermissionsAcls:
   #- "-m everyone@:full_set:allow"
   #- "-m u:kube:full_set:allow"

--- a/examples/freenas-api-smb.yaml
+++ b/examples/freenas-api-smb.yaml
@@ -52,7 +52,7 @@ zfs:
   datasetPermissionsUser: 0
   datasetPermissionsGroup: 0
   
-  # not supported yet in api
+  # not supported yet in api (silently ignored); use an SSH-based driver if you need dataset ACLs
   #datasetPermissionsAcls:
   #- "-m everyone@:full_set:allow"
   #- "-m u:kube:full_set:allow"

--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -8,7 +8,6 @@ const Mount = require("../../utils/mount").Mount;
 const Handlebars = require("handlebars");
 const uuidv4 = require("uuid").v4;
 const semver = require("semver");
-const yaml = require("js-yaml");
 
 // zfs common properties
 const MANAGED_PROPERTY_NAME = "democratic-csi:managed_resource";
@@ -642,63 +641,7 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     const execClient = this.getExecClient();
     const zb = await this.getZetabyte();
 
-    const normalizedParameters = driver.getNormalizedParameters(
-      call.request.parameters,
-      driver.options.driver,
-      driver.options.instance_id
-    );
-
-    let parametersOptions = {};
-    if (normalizedParameters["config"]) {
-      try {
-        parametersOptions = yaml.load(normalizedParameters["config"]);
-      } catch (err) {
-        if (err instanceof yaml.YAMLException) {
-          throw new GrpcError(
-            grpc.status.INVALID_ARGUMENT,
-            `parameter 'config' not a valid YAML/JSON document.`.trim()
-          );
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    let pvcOptions = {};
-    if (
-      normalizedParameters["load-config-from-pvc"] == "true" &&
-      call.request.parameters["csi.storage.k8s.io/pvc/name"] &&
-      call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
-    ) {
-      let pvc = await driver.getPersistentVolumeClaim(
-        call.request.parameters["csi.storage.k8s.io/pvc/name"],
-        call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
-      );
-
-      if (
-        _.has(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
-      ) {
-        try {
-          pvcOptions = yaml.load(
-            _.get(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
-          );
-        } catch (err) {
-          if (err instanceof yaml.YAMLException) {
-            throw new GrpcError(
-              grpc.status.INVALID_ARGUMENT,
-              `pvc 'democratic-csi.org/config' annotation not a valid YAML/JSON document.`.trim()
-            );
-          } else {
-            throw err;
-          }
-        }
-      }
-    }
-
-    const driverOptions = driver.getMergedDriverOptions([
-      parametersOptions,
-      pvcOptions,
-    ]);
+    const driverOptions = await driver.getDriverOptionsFromCall(call);
 
     let datasetParentName = this.getVolumeParentDatasetName();
     let snapshotParentDatasetName = this.getDetachedSnapshotParentDatasetName();

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -9,7 +9,6 @@ const GeneralUtils = require("../../utils/general");
 const Handlebars = require("handlebars");
 const uuidv4 = require("uuid").v4;
 const semver = require("semver");
-const yaml = require("js-yaml");
 
 // freenas properties
 const FREENAS_NFS_SHARE_PROPERTY_NAME = "democratic-csi:freenas_nfs_share_id";
@@ -2637,63 +2636,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
-    const normalizedParameters = driver.getNormalizedParameters(
-      call.request.parameters,
-      driver.options.driver,
-      driver.options.instance_id
-    );
-
-    let parametersOptions = {};
-    if (normalizedParameters["config"]) {
-      try {
-        parametersOptions = yaml.load(normalizedParameters["config"]);
-      } catch (err) {
-        if (err instanceof yaml.YAMLException) {
-          throw new GrpcError(
-            grpc.status.INVALID_ARGUMENT,
-            `parameter 'config' not a valid YAML/JSON document.`.trim()
-          );
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    let pvcOptions = {};
-    if (
-      normalizedParameters["load-config-from-pvc"] == "true" &&
-      call.request.parameters["csi.storage.k8s.io/pvc/name"] &&
-      call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
-    ) {
-      let pvc = await driver.getPersistentVolumeClaim(
-        call.request.parameters["csi.storage.k8s.io/pvc/name"],
-        call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
-      );
-
-      if (
-        _.has(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
-      ) {
-        try {
-          pvcOptions = yaml.load(
-            _.get(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
-          );
-        } catch (err) {
-          if (err instanceof yaml.YAMLException) {
-            throw new GrpcError(
-              grpc.status.INVALID_ARGUMENT,
-              `pvc 'democratic-csi.org/config' annotation not a valid YAML/JSON document.`.trim()
-            );
-          } else {
-            throw err;
-          }
-        }
-      }
-    }
-
-    const driverOptions = driver.getMergedDriverOptions([
-      parametersOptions,
-      pvcOptions,
-    ]);
+    const driverOptions = await driver.getDriverOptionsFromCall(call);
 
     let datasetParentName = this.getVolumeParentDatasetName();
     let snapshotParentDatasetName = this.getDetachedSnapshotParentDatasetName();

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -3366,15 +3366,26 @@ class FreeNASApiDriver extends CsiBaseDriver {
         }
 
         // set acls
-        // TODO: this is unsfafe approach, make it better
-        // probably could see if ^-.*\s and split and then shell escape
+        //
+        // NOT IMPLEMENTED for the API driver (no-op). The `datasetPermissionsAcls`
+        // config option is a list of raw `setfacl`-style CLI argument strings
+        // (e.g. "-m u:kube:full_set:allow"), which is what the SSH-based driver
+        // shells out with. The TrueNAS middleware exposes `filesystem.setacl`, but
+        // it expects a *structured* `dacl` array of ACE objects (tag/id/type/perms/
+        // flags), not setfacl strings, and the ACE schema further differs between
+        // NFSv4 (Core, and SCALE with acltype=nfsv4) and POSIX1e (SCALE). There is
+        // no safe, lossless way to translate the CLI-string format into the API
+        // payload here, so this is intentionally left unimplemented rather than
+        // applying potentially-wrong permissions. Implementing it would require a
+        // new structured config option dedicated to the API drivers.
+        // See docs/storage-class-parameters.md for the user-facing note.
         if (driverOptions.zfs.datasetPermissionsAcls) {
           for (const acl of driverOptions.zfs.datasetPermissionsAcls) {
             perms = {
               path: properties.mountpoint.value,
               dacl: acl,
             };
-            // TODO: FilesystemSetacl?
+            // TODO: FilesystemSetacl? (see note above)
           }
         }
 

--- a/src/driver/freenas/api.js
+++ b/src/driver/freenas/api.js
@@ -9,6 +9,7 @@ const GeneralUtils = require("../../utils/general");
 const Handlebars = require("handlebars");
 const uuidv4 = require("uuid").v4;
 const semver = require("semver");
+const yaml = require("js-yaml");
 
 // freenas properties
 const FREENAS_NFS_SHARE_PROPERTY_NAME = "democratic-csi:freenas_nfs_share_id";
@@ -2636,9 +2637,67 @@ class FreeNASApiDriver extends CsiBaseDriver {
     const httpApiClient = await this.getTrueNASHttpApiClient();
     const zb = await this.getZetabyte();
 
+    const normalizedParameters = driver.getNormalizedParameters(
+      call.request.parameters,
+      driver.options.driver,
+      driver.options.instance_id
+    );
+
+    let parametersOptions = {};
+    if (normalizedParameters["config"]) {
+      try {
+        parametersOptions = yaml.load(normalizedParameters["config"]);
+      } catch (err) {
+        if (err instanceof yaml.YAMLException) {
+          throw new GrpcError(
+            grpc.status.INVALID_ARGUMENT,
+            `parameter 'config' not a valid YAML/JSON document.`.trim()
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    let pvcOptions = {};
+    if (
+      normalizedParameters["load-config-from-pvc"] == "true" &&
+      call.request.parameters["csi.storage.k8s.io/pvc/name"] &&
+      call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
+    ) {
+      let pvc = await driver.getPersistentVolumeClaim(
+        call.request.parameters["csi.storage.k8s.io/pvc/name"],
+        call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
+      );
+
+      if (
+        _.has(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
+      ) {
+        try {
+          pvcOptions = yaml.load(
+            _.get(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
+          );
+        } catch (err) {
+          if (err instanceof yaml.YAMLException) {
+            throw new GrpcError(
+              grpc.status.INVALID_ARGUMENT,
+              `pvc 'democratic-csi.org/config' annotation not a valid YAML/JSON document.`.trim()
+            );
+          } else {
+            throw err;
+          }
+        }
+      }
+    }
+
+    const driverOptions = driver.getMergedDriverOptions([
+      parametersOptions,
+      pvcOptions,
+    ]);
+
     let datasetParentName = this.getVolumeParentDatasetName();
     let snapshotParentDatasetName = this.getDetachedSnapshotParentDatasetName();
-    let zvolBlocksize = this.options.zfs.zvolBlocksize || "16K";
+    let zvolBlocksize = driverOptions.zfs.zvolBlocksize || "16K";
     let name = call.request.name;
     let volume_id = await driver.getVolumeIdFromCall(call);
     let volume_content_source = call.request.volume_content_source;
@@ -2768,7 +2827,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
       if (
         driverZfsResourceType == "filesystem" &&
-        this.options.zfs.datasetEnableQuotas
+        driverOptions.zfs.datasetEnableQuotas
       ) {
         check = true;
       }
@@ -2822,9 +2881,9 @@ class FreeNASApiDriver extends CsiBaseDriver {
 
     // user-supplied properties
     // put early to prevent stupid (user-supplied values overwriting system values)
-    if (driver.options.zfs.datasetProperties) {
-      for (let property in driver.options.zfs.datasetProperties) {
-        let value = driver.options.zfs.datasetProperties[property];
+    if (driverOptions.zfs.datasetProperties) {
+      for (let property in driverOptions.zfs.datasetProperties) {
+        let value = driverOptions.zfs.datasetProperties[property];
         const template = Handlebars.compile(value);
 
         volumeProperties[property] = template({
@@ -2836,10 +2895,10 @@ class FreeNASApiDriver extends CsiBaseDriver {
     volumeProperties[VOLUME_CSI_NAME_PROPERTY_NAME] = name;
     volumeProperties[MANAGED_PROPERTY_NAME] = "true";
     volumeProperties[VOLUME_CONTEXT_PROVISIONER_DRIVER_PROPERTY_NAME] =
-      driver.options.driver;
-    if (driver.options.instance_id) {
+      driverOptions.driver;
+    if (driverOptions.instance_id) {
       volumeProperties[VOLUME_CONTEXT_PROVISIONER_INSTANCE_ID_PROPERTY_NAME] =
-        driver.options.instance_id;
+        driverOptions.instance_id;
     }
 
     // TODO: also set access_mode as property?
@@ -2850,10 +2909,10 @@ class FreeNASApiDriver extends CsiBaseDriver {
     let sparse;
     if (driverZfsResourceType == "volume") {
       // this is managed by the `sparse` option in the api
-      if (!this.options.zfs.zvolEnableReservation) {
+      if (!driverOptions.zfs.zvolEnableReservation) {
         volumeProperties.refreservation = 0;
       }
-      sparse = Boolean(!this.options.zfs.zvolEnableReservation);
+      sparse = Boolean(!driverOptions.zfs.zvolEnableReservation);
     }
 
     let detachedClone = false;
@@ -3211,13 +3270,13 @@ class FreeNASApiDriver extends CsiBaseDriver {
     switch (driverZfsResourceType) {
       case "filesystem":
         // set quota
-        if (this.options.zfs.datasetEnableQuotas) {
+        if (driverOptions.zfs.datasetEnableQuotas) {
           setProps = true;
           properties.refquota = Number(capacity_bytes);
         }
 
         // set reserve
-        if (this.options.zfs.datasetEnableReservation) {
+        if (driverOptions.zfs.datasetEnableReservation) {
           setProps = true;
           properties.refreservation = Number(capacity_bytes);
         }
@@ -3249,46 +3308,46 @@ class FreeNASApiDriver extends CsiBaseDriver {
         let perms = {
           path: properties.mountpoint.value,
         };
-        if (this.options.zfs.datasetPermissionsMode) {
+        if (driverOptions.zfs.datasetPermissionsMode) {
           setPerms = true;
-          perms.mode = this.options.zfs.datasetPermissionsMode;
+          perms.mode = driverOptions.zfs.datasetPermissionsMode;
         }
 
         // set ownership
         if (
-          this.options.zfs.hasOwnProperty("datasetPermissionsUser") ||
-          this.options.zfs.hasOwnProperty("datasetPermissionsGroup")
+          driverOptions.zfs.hasOwnProperty("datasetPermissionsUser") ||
+          driverOptions.zfs.hasOwnProperty("datasetPermissionsGroup")
         ) {
           setPerms = true;
         }
 
         // user
-        if (this.options.zfs.hasOwnProperty("datasetPermissionsUser")) {
+        if (driverOptions.zfs.hasOwnProperty("datasetPermissionsUser")) {
           if (
-            String(this.options.zfs.datasetPermissionsUser).match(/^[0-9]+$/) ==
+            String(driverOptions.zfs.datasetPermissionsUser).match(/^[0-9]+$/) ==
             null
           ) {
             throw new GrpcError(
               grpc.status.FAILED_PRECONDITION,
-              `datasetPermissionsUser must be numeric: ${this.options.zfs.datasetPermissionsUser}`
+              `datasetPermissionsUser must be numeric: ${driverOptions.zfs.datasetPermissionsUser}`
             );
           }
-          perms.uid = Number(this.options.zfs.datasetPermissionsUser);
+          perms.uid = Number(driverOptions.zfs.datasetPermissionsUser);
         }
 
         // group
-        if (this.options.zfs.hasOwnProperty("datasetPermissionsGroup")) {
+        if (driverOptions.zfs.hasOwnProperty("datasetPermissionsGroup")) {
           if (
-            String(this.options.zfs.datasetPermissionsGroup).match(
+            String(driverOptions.zfs.datasetPermissionsGroup).match(
               /^[0-9]+$/
             ) == null
           ) {
             throw new GrpcError(
               grpc.status.FAILED_PRECONDITION,
-              `datasetPermissionsGroup must be numeric: ${this.options.zfs.datasetPermissionsGroup}`
+              `datasetPermissionsGroup must be numeric: ${driverOptions.zfs.datasetPermissionsGroup}`
             );
           }
-          perms.gid = Number(this.options.zfs.datasetPermissionsGroup);
+          perms.gid = Number(driverOptions.zfs.datasetPermissionsGroup);
         }
 
         if (setPerms) {
@@ -3309,8 +3368,8 @@ class FreeNASApiDriver extends CsiBaseDriver {
         // set acls
         // TODO: this is unsfafe approach, make it better
         // probably could see if ^-.*\s and split and then shell escape
-        if (this.options.zfs.datasetPermissionsAcls) {
-          for (const acl of this.options.zfs.datasetPermissionsAcls) {
+        if (driverOptions.zfs.datasetPermissionsAcls) {
+          for (const acl of driverOptions.zfs.datasetPermissionsAcls) {
             perms = {
               path: properties.mountpoint.value,
               dacl: acl,
@@ -3335,21 +3394,21 @@ class FreeNASApiDriver extends CsiBaseDriver {
         // restore default must use the below
         // zfs inherit [-rS] property filesystem|volume|snapshot…
         if (
-          (typeof this.options.zfs.zvolDedup === "string" ||
-            this.options.zfs.zvolDedup instanceof String) &&
-          this.options.zfs.zvolDedup.length > 0
+          (typeof driverOptions.zfs.zvolDedup === "string" ||
+            driverOptions.zfs.zvolDedup instanceof String) &&
+          driverOptions.zfs.zvolDedup.length > 0
         ) {
-          properties.dedup = this.options.zfs.zvolDedup;
+          properties.dedup = driverOptions.zfs.zvolDedup;
         }
 
         // compression
         // lz4, gzip-9, etc
         if (
-          (typeof this.options.zfs.zvolCompression === "string" ||
-            this.options.zfs.zvolCompression instanceof String) &&
-          this.options.zfs.zvolCompression > 0
+          (typeof driverOptions.zfs.zvolCompression === "string" ||
+            driverOptions.zfs.zvolCompression instanceof String) &&
+          driverOptions.zfs.zvolCompression > 0
         ) {
-          properties.compression = this.options.zfs.zvolCompression;
+          properties.compression = driverOptions.zfs.zvolCompression;
         }
 
         if (setProps) {
@@ -3364,10 +3423,10 @@ class FreeNASApiDriver extends CsiBaseDriver {
       [SHARE_VOLUME_CONTEXT_PROPERTY_NAME]: JSON.stringify(volume_context),
     });
 
-    volume_context["provisioner_driver"] = driver.options.driver;
-    if (driver.options.instance_id) {
+    volume_context["provisioner_driver"] = driverOptions.driver;
+    if (driverOptions.instance_id) {
       volume_context["provisioner_driver_instance_id"] =
-        driver.options.instance_id;
+        driverOptions.instance_id;
     }
 
     // set this just before sending out response so we know if volume completed
@@ -3381,7 +3440,7 @@ class FreeNASApiDriver extends CsiBaseDriver {
         volume_id,
         //capacity_bytes: capacity_bytes, // kubernetes currently pukes if capacity is returned as 0
         capacity_bytes:
-          this.options.zfs.datasetEnableQuotas ||
+          driverOptions.zfs.datasetEnableQuotas ||
           driverZfsResourceType == "volume"
             ? capacity_bytes
             : 0,

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -15,6 +15,7 @@ const { NVMEoF } = require("../utils/nvmeof");
 const semver = require("semver");
 const GeneralUtils = require("../utils/general");
 const { Zetabyte } = require("../utils/zfs");
+const yaml = require("js-yaml");
 
 const __REGISTRY_NS__ = "CsiBaseDriver";
 
@@ -134,6 +135,76 @@ class CsiBaseDriver {
     });
 
     return driverOptions;
+  }
+
+  /**
+   * Resolve the effective driver options for a CreateVolume call by merging the
+   * base driver configuration with any overrides supplied on a per-`StorageClass`
+   * basis (the `config` parameter) and/or per-`PersistentVolumeClaim` basis (the
+   * `democratic-csi.org/config` annotation, gated by the `load-config-from-pvc`
+   * parameter). Only the properties in `getMergedDriverOptions`'s allow-list are
+   * actually overridable; everything else falls back to the driver configuration.
+   *
+   * @param {*} call the grpc CreateVolume call
+   * @returns merged driver options
+   */
+  async getDriverOptionsFromCall(call) {
+    const driver = this;
+
+    const normalizedParameters = driver.getNormalizedParameters(
+      call.request.parameters,
+      driver.options.driver,
+      driver.options.instance_id
+    );
+
+    let parametersOptions = {};
+    if (normalizedParameters["config"]) {
+      try {
+        parametersOptions = yaml.load(normalizedParameters["config"]);
+      } catch (err) {
+        if (err instanceof yaml.YAMLException) {
+          throw new GrpcError(
+            grpc.status.INVALID_ARGUMENT,
+            `parameter 'config' not a valid YAML/JSON document.`.trim()
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    let pvcOptions = {};
+    if (
+      normalizedParameters["load-config-from-pvc"] == "true" &&
+      call.request.parameters["csi.storage.k8s.io/pvc/name"] &&
+      call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
+    ) {
+      let pvc = await driver.getPersistentVolumeClaim(
+        call.request.parameters["csi.storage.k8s.io/pvc/name"],
+        call.request.parameters["csi.storage.k8s.io/pvc/namespace"]
+      );
+
+      if (
+        _.has(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
+      ) {
+        try {
+          pvcOptions = yaml.load(
+            _.get(pvc, ["metadata", "annotations", "democratic-csi.org/config"])
+          );
+        } catch (err) {
+          if (err instanceof yaml.YAMLException) {
+            throw new GrpcError(
+              grpc.status.INVALID_ARGUMENT,
+              `pvc 'democratic-csi.org/config' annotation not a valid YAML/JSON document.`.trim()
+            );
+          } else {
+            throw err;
+          }
+        }
+      }
+    }
+
+    return driver.getMergedDriverOptions([parametersOptions, pvcOptions]);
   }
 
   /**

--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -108,7 +108,13 @@ class CsiBaseDriver {
     const driver = this;
     let driverOptions = Object.assign({}, driver.options);
 
-    const allowedOptionsOverrides = ["zfs.zvolBlocksize"];
+    const allowedOptionsOverrides = [
+      "zfs.zvolBlocksize",
+      "zfs.zvolDedup",
+      "zfs.zvolCompression",
+      "zfs.zvolEnableReservation",
+      "zfs.datasetProperties",
+    ];
 
     optionOverlays.forEach((optionOverlay) => {
       allowedOptionsOverrides.forEach((prop) => {


### PR DESCRIPTION
This pull request introduces a major enhancement to the ZFS-backed drivers by enabling support for per-`StorageClass` and per-`PersistentVolumeClaim` (PVC) overrides of certain ZFS dataset and zvol options. The implementation centralizes and standardizes how driver options are merged from configuration, `StorageClass`, and PVC annotations, and updates both documentation and code to reflect this new flexibility. Additionally, it clarifies the handling of ACLs for API-based drivers. Notably, this brings the API-based freenas-api-* / truenas-api-* drivers to parity with the SSH-based freenas-* / truenas-* drivers, which already supported these per-StorageClass and per-PVC overrides.

**ZFS Option Overrides and Driver Option Handling**

* Added support for overriding a subset of ZFS options (such as `zfs.zvolBlocksize`, `zfs.zvolDedup`, `zfs.zvolCompression`, `zfs.zvolEnableReservation`, and `zfs.datasetProperties`) on a per-`StorageClass` and per-PVC basis, with clear documentation and examples.
* Refactored option merging logic: introduced a new `getDriverOptionsFromCall` method in `CsiBaseDriver` that handles merging driver options from configuration, `StorageClass` `config`, and PVC annotation, and updated all ZFS-backed drivers to use this method. [[1]](diffhunk://#diff-76b96006b62a060c9c3aa006073d3a911893192970de0530a15495200d2a5e63L645-R644) [[2]](diffhunk://#diff-5dbebab20b00aa3f909bc49b4247e83d039f01c03ce49b7981b85cacf42c54baR2639-R2643) [[3]](diffhunk://#diff-71ccdb9c9c1e585384b1be4a73618640e30de2b678ecf06e19896aa7209b81f6L111-R118) [[4]](diffhunk://#diff-71ccdb9c9c1e585384b1be4a73618640e30de2b678ecf06e19896aa7209b81f6R18)

**Documentation Updates**

* Expanded `docs/storage-class-parameters.md` to document the new override mechanism, supported options, and caveats regarding ACLs and option precedence.
* Updated example manifests and in-line documentation to clarify that dataset ACLs are not supported in API-based drivers and are silently ignored, with guidance to use SSH-based drivers if ACLs are required. [[1]](diffhunk://#diff-af8a13242c8e008c2a75f795da7812749dd0dcb9e4809e9327bff29b8a356a76L50-R50) [[2]](diffhunk://#diff-bd8ae3f88287c96240050157ffa5f3643d56ce3d1f18629f2ca2eeac48f5307dL55-R55)

These changes make it much easier for users to customize ZFS provisioning behavior without deploying multiple driver instances, while ensuring safe and predictable handling of options and permissions.