### PR TITLE
fix(iscsi): logout orphaned sessions when device correlation fails

### DIFF
--- a/src/driver/index.js
+++ b/src/driver/index.js
@@ -2637,6 +2637,7 @@ class CsiBaseDriver {
 
         if (is_block) {
           let breakdeviceloop = false;
+          let matched_session_by_device = false;
           let realBlockDeviceInfos = [];
           // detect if is a multipath device
           is_device_mapper = await filesystem.isDeviceMapperDevice(
@@ -2701,6 +2702,7 @@ class CsiBaseDriver {
                       }
 
                       if (is_attached_to_session) {
+                        matched_session_by_device = true;
                         let timer_start;
                         let timer_max;
 
@@ -2779,6 +2781,62 @@ class CsiBaseDriver {
                   }
                 }
                 break;
+            }
+          }
+
+          /**
+           * if the device(s) could not be correlated to a session above the
+           * logout never happened, leaving the session to reconnect forever
+           * (https://github.com/democratic-csi/democratic-csi/issues/536)
+           *
+           * fall back to the iqn from the volume_context, but only log out
+           * when that target has exactly 1 lun attached: with several luns on
+           * a single target (node-manual) a logout would tear down volumes
+           * still in use elsewhere
+           */
+          if (!matched_session_by_device) {
+            const volume_context = await driver.getDerivedVolumeContext(call);
+            const iqn = _.get(volume_context, "iqn");
+            if (iqn) {
+              const sessions = await iscsi.iscsiadm.getSessionsDetails();
+              for (const session of sessions) {
+                if (session.target != iqn) {
+                  continue;
+                }
+                const luns = _.get(
+                  session,
+                  "attached_scsi_devices.host.devices",
+                  []
+                ).length;
+                if (luns > 1) {
+                  driver.ctx.logger.warn(
+                    `refusing orphaned session logout, target has ${luns} luns attached: ${iqn}`
+                  );
+                  continue;
+                }
+                driver.ctx.logger.warn(
+                  `logging out of orphaned iscsi session: ${iqn}`
+                );
+                await GeneralUtils.retry(15, 2000, async () => {
+                  await iscsi.iscsiadm.logout(session.target, [
+                    session.persistent_portal,
+                  ]);
+                }).catch((err) => {
+                  driver.ctx.logger.warn(
+                    `failed to logout of orphaned session ${iqn}: ${err.message}`
+                  );
+                });
+                await GeneralUtils.retry(15, 2000, async () => {
+                  await iscsi.iscsiadm.deleteNodeDBEntry(
+                    session.target,
+                    session.persistent_portal
+                  );
+                }).catch((err) => {
+                  driver.ctx.logger.warn(
+                    `failed to delete node db entry ${iqn}: ${err.message}`
+                  );
+                });
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes #536 (or attempts to -- see the honesty section below).

## Problem

`NodeUnstageVolume` picks the session to log out of by matching the local block device against each session's attached SCSI disks. When the backing device is gone or no longer correlates -- zvol destroyed, or the target vanished before the unstage call -- that match never succeeds, the logout is skipped, and iscsid retries the login forever.

From my cluster, the full lifecycle of one volume:

```
02:01:29  zfs clone            volume created
02:01:45  targetcli            target created
02:01:49  AttachVolume.Attach  succeeded
02:26:48  Unable to locate Target IQN   <-- first error
02:26:49  zfs destroy          volume destroyed
```

No logout is ever logged for that iqn. Each orphan retries ~4x/sec indefinitely; eight of them put a 6-core node at load 56 with ~14,300 kernel errors/hour, while Kubernetes still reported it `Ready`.

## Change

58 lines, one file. When the device loop finishes without matching any session, resolve the iqn through `getDerivedVolumeContext()` and log out of that target directly.

On the multi-lun concern you raised in the issue: the fallback **skips any target with more than one attached lun**. With `node-manual` several volumes can share a target, and logging out would tear down volumes still in use. So the multi-lun case still leaks the session, but it fails closed instead of causing damage, and nothing changes for the existing device-matched path.

Failures in logout and node DB deletion log a warning and continue, matching what the device-matched path already does.

## Honesty about verification

**I could not test this.** No lab to reproduce against, and the csi-sanity matrix needs storage backends and self-hosted runners I do not have.

What I actually verified:
- `node --check` passes
- `GeneralUtils.retry(retries, delay, code)` signature matches usage
- the decision logic reasoned through by hand, including the multi-lun guard
- prettier reports the same pre-existing warning on this file before and after my change

What I did **not** verify: the runtime path. Whether `getDerivedVolumeContext(call)` resolves correctly inside `NodeUnstageVolume` is unproven. It is already called in three other node methods, so the pattern should hold, but that is inference, not evidence.

Analysis of the local behaviour says this should fix it. If you are willing to run it through your test pipeline, that would settle whether it actually does. Happy to rework the approach, split it differently, or close it if the shape is wrong.