### PR TITLE
fix(controller-zfs): unmount before destroy so deletes work on LXC hosts

### DIFF
--- a/src/driver/controller-zfs/index.js
+++ b/src/driver/controller-zfs/index.js
@@ -1471,6 +1471,20 @@ class ControllerZfsBaseDriver extends CsiBaseDriver {
     // NOTE: -f does NOT allow deletes if dependent filesets exist
     // NOTE: -R will recursively delete items + dependent filesets
     // delete dataset
+    // Unmount explicitly before destroying. `zfs destroy -f` forces the
+    // unmount via umount2(MNT_FORCE), which LXC's default seccomp profile
+    // rejects (`reject_force_umount`), so on a containerised ZFS host every
+    // delete of a mounted dataset fails with "cannot unmount ... unmount
+    // failed" and never recovers. A plain unmount is permitted there.
+    //
+    // Best-effort: a dataset that is a zvol, already unmounted, or absent has
+    // nothing to unmount, and any real problem still surfaces from destroy.
+    try {
+      await zb.zfs.unmount(datasetName, { idempotent: true });
+    } catch (err) {
+      // fall through to destroy, which reports the actionable error
+    }
+
     try {
       await GeneralUtils.retry(
         12,

--- a/src/utils/zfs.js
+++ b/src/utils/zfs.js
@@ -1445,6 +1445,53 @@ class Zetabyte {
        * @param {*} dataset
        * @param {*} property
        */
+      /**
+       * zfs unmount [-f] filesystem|mountpoint
+       *
+       * Deliberately does NOT support -f. A forced unmount issues
+       * umount2(MNT_FORCE), which LXC's default seccomp profile rejects
+       * (`reject_force_umount`), so it fails with EPERM on containerised ZFS
+       * hosts. A plain unmount is permitted there and is sufficient.
+       *
+       * @param {*} dataset
+       * @param {*} options
+       */
+      unmount: function (dataset, options = {}) {
+        if (!(arguments.length >= 1)) throw Error("Invalid arguments");
+
+        return new Promise((resolve, reject) => {
+          const idempotent =
+            "idempotent" in options
+              ? options.idempotent
+              : "idempotent" in zb.options
+              ? zb.options.idempotent
+              : false;
+
+          let args = [];
+          args.push("unmount");
+          args.push(dataset);
+
+          zb.exec(
+            zb.options.paths.zfs,
+            args,
+            { timeout: zb.options.timeout },
+            function (error, stdout, stderr) {
+              if (
+                error &&
+                !(
+                  idempotent &&
+                  (stderr.includes("not currently mounted") ||
+                    stderr.includes("not a mountpoint") ||
+                    stderr.includes("dataset does not exist"))
+                )
+              )
+                return reject(zb.helpers.zfsError(error, stderr));
+              return resolve(stdout);
+            }
+          );
+        });
+      },
+
       inherit: function (dataset, property) {
         if (arguments.length != 2) throw Error("Invalid arguments");
 


### PR DESCRIPTION
Fixes #570.

### Problem

`DeleteVolume` destroys with `zfs destroy -r -f -p`. The `-f` forces the unmount, which issues `umount2(MNT_FORCE)`. LXC's default seccomp profile rejects that syscall:

```
# /usr/share/lxc/config/common.seccomp
reject_force_umount  # comment this to allow umount -f;  not recommended
```

So on a ZFS server running inside an LXC container — a common way to run `zfs-generic-nfs` on Proxmox — every delete of a mounted dataset fails with:

```
rpc error: code = Internal desc = Error: cannot unmount
  '/<parent-mountpoint>/pvc-xxxxxxxx-...': unmount failed
    at Object.zfsError (/home/csi/app/src/utils/zfs.js:78:16)
```

The PV stays `Released` and the dataset is stranded. It never recovers: the existing `GeneralUtils.retry` in `DeleteVolume` only retries on `"dataset is busy"` / `"target is busy"`, which this error does not match.

### Fix

A plain, non-forced unmount *is* permitted inside such containers, so unmount explicitly before destroying.

- adds an `unmount()` helper to `src/utils/zfs.js`, following the existing `inherit()`/`destroy()` style and supporting the codebase's `idempotent` option. It deliberately does not support `-f`.
- calls it best-effort before the existing destroy in `controller-zfs`. Zvols, already-unmounted and absent datasets have nothing to unmount, and any real problem still surfaces from the `destroy` that follows.

Purely additive — 61 insertions, no existing behavior changed. The `-f` on `destroy` is left in place; it simply becomes a no-op because the dataset is already unmounted, so no `umount2(MNT_FORCE)` is issued.

### Verification

Built and ran against a live cluster (single-node Talos + a Debian 12 LXC ZFS host).

Provisioned a 1Gi PVC — dataset created, `refquota=1G`, `mounted=yes`, the exact condition that failed before. Deleting the PVC then removed the PV and destroyed the dataset automatically, first attempt, no retries. From `sudo`'s journal on the storage host:

```
zfs unmount local-main/.../pvc-19016e00-...
zfs destroy -r -f -p local-main/.../pvc-19016e00-...
```

Re-confirmed afterwards on the unpatched upstream image that the same create/delete cycle still fails with `cannot unmount ... unmount failed`, so this is a real and current failure rather than an environment quirk.

### Note

An alternative would be making the `-f` configurable, which I mentioned in #570. I went with unmounting first because it needs no new config knob and is correct on non-containerised hosts too. Happy to switch if you prefer the flag.

This also overlaps with #567 (decoupling mount/unmount in this driver); a general "don't perform mount/unmount implicitly inside other zfs commands" change would subsume it.

### Environment

| | |
|---|---|
| driver | `zfs-generic-nfs` |
| storage host | Debian 12 LXC (privileged, `nesting=1`, `/dev/zfs` passthrough) on Proxmox |
| zfs | userspace 2.1.11-1+deb12u1, kmod 2.2.8-pve1 |
| kernel | 6.8.12-12-pve |
| kubernetes | 1.35.4 |
| share strategy | `setDatasetProperties` (sharenfs) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)